### PR TITLE
ISSUE 19: Error: could not find config file /etc/supervisord.conf

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -79,7 +79,7 @@ if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor ]; then
 fi
 
 if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor -maxdepth 1 -type f) ]]; then
-		CMD=$(cp -R etc/services-config/supervisor/ ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor/)
+		CMD=$(cp -R etc/services-config/supervisor ${CONTAINER_MOUNT_PATH_CONFIG}/)
 		$CMD || sudo $CMD
 fi
 
@@ -89,7 +89,7 @@ if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/httpd ]; then
 fi
 
 if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/httpd -maxdepth 1 -type f) ]]; then
-		CMD=$(cp -R etc/services-config/httpd/ ${CONTAINER_MOUNT_PATH_CONFIG}/httpd/)
+		CMD=$(cp -R etc/services-config/httpd ${CONTAINER_MOUNT_PATH_CONFIG}/)
 		$CMD || sudo $CMD
 fi
 


### PR DESCRIPTION
On non Darwin docker hosts the cp -R syntax appears to be different resulting in the supervisor directory being copied into place on first run instead of it's contents.