### PR TITLE
ISSUE 39: Add Apache module reqtimeout_module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN sed -i \
 	-e 's~^#LoadModule deflate_module ~LoadModule deflate_module ~g' \
 	-e 's~^#LoadModule headers_module ~LoadModule headers_module ~g' \
 	-e 's~^#LoadModule alias_module ~LoadModule alias_module ~g' \
+	-e 's~^\(#LoadModule version_module modules/mod_version.so\)$~\1\n#LoadModule reqtimeout_module modules/mod_reqtimeout.so~g' \
 	/etc/httpd/conf/httpd.conf
 
 # -----------------------------------------------------------------------------

--- a/etc/services-config/httpd/conf/httpd.conf
+++ b/etc/services-config/httpd/conf/httpd.conf
@@ -199,6 +199,7 @@ LoadModule alias_module modules/mod_alias.so
 #LoadModule disk_cache_module modules/mod_disk_cache.so
 #LoadModule cgi_module modules/mod_cgi.so
 #LoadModule version_module modules/mod_version.so
+#LoadModule reqtimeout_module modules/mod_reqtimeout.so
 
 #
 # The following modules are not loaded by default:
@@ -1016,8 +1017,8 @@ Listen 8443
 NameVirtualHost *:80
 NameVirtualHost *:8443
 #NameVirtualHost *:443
-Include /var/www/app/vhost.conf
-#Include /var/www/app/vhost-ssl.conf
+Include ${APP_HOME_DIR}/vhost.conf
+#Include ${APP_HOME_DIR}/vhost-ssl.conf
 
 <Location /server-status>
     SetHandler server-status

--- a/var/www/app/vhost.conf
+++ b/var/www/app/vhost.conf
@@ -160,4 +160,8 @@
                 php_value xdebug.remote_connect_back On
                 php_value xdebug.profiler_enable_trigger On
         </IfModule>
+
+        <IfModule mod_reqtimeout.c>
+                RequestReadTimeout header=20-40,MinRate=500 body=20,MinRate=500
+        </IfModule>
 </VirtualHost>


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-apache-php/issues/39

Also includes an update to the static copy of httpd.conf to make use of the APP_HOME_DIR environment variable instead of hard coding the path.