### PR TITLE
ISSUE 58: Updated source tag to 1.4.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.4.0
+FROM jdeathe/centos-ssh:centos-6-1.4.1
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-apache-php/issues/58