### PR TITLE
ISSUE 40: Add localhost ServerStatus using URI /_httpdstatus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN sed -i \
 	-e 's~^ServerTokens OS$~ServerTokens Prod~g' \
 	-e 's~^#ExtendedStatus On$~ExtendedStatus On~g' \
 	-e 's~^DirectoryIndex \(.*\)$~DirectoryIndex \1 index.php~g' \
+	-e 's~^NameVirtualHost \(.*\)$~#NameVirtualHost \1~g' \
 	/etc/httpd/conf/httpd.conf
 
 # -----------------------------------------------------------------------------
@@ -110,6 +111,7 @@ RUN { \
 		echo '#'; \
 		echo 'Options -Indexes'; \
 		echo 'Listen 8443'; \
+		echo 'NameVirtualHost *:80'; \
 		echo 'NameVirtualHost *:8443'; \
 		echo 'Include ${APP_HOME_DIR}/vhost.conf'; \
 	} >> /etc/httpd/conf/httpd.conf \

--- a/etc/apache-bootstrap
+++ b/etc/apache-bootstrap
@@ -91,7 +91,7 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] && [[ ! -f ${OPTS_APP_HOME_DIR}/
 
 	# Enable the SSL VirtualHosts configuration
 	sed -i \
-		-e 's~^<VirtualHost \*:80>$~#<VirtualHost \*:80>~g' \
+		-e 's~^<VirtualHost \*:80 \*:8443>$~#<VirtualHost \*:80 \*:8443>~g' \
 		-e 's~^#<VirtualHost \*:443>$~<VirtualHost \*:443>~g' \
 		-e 's~#SSLEngine \(.*\)$~SSLEngine \1~g' \
 		-e 's~#SSLOptions \(.*\)$~SSLOptions \1~g' \
@@ -105,13 +105,7 @@ fi
 # Enable/Disable SSL support
 if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 	echo "Enabling SSL support."
-
 	cat /etc/httpd/conf.d/ssl.conf.off > /etc/httpd/conf.d/ssl.conf
-
-	sed -i \
-		-e 's~^#NameVirtualHost \*:443$~NameVirtualHost \*:443~g' \
-		-e 's~^#Include ${OPTS_APP_HOME_DIR}/vhost-ssl.conf$~Include ${OPTS_APP_HOME_DIR}/vhost-ssl.conf~g' \
-		/etc/httpd/conf/httpd.conf
 
 	if [[ ! -f /etc/services-config/ssl/private/localhost.key ]] || [[ ! -f /etc/services-config/ssl/certs/localhost.crt ]]; then
 		echo "Generating new certificate."
@@ -129,11 +123,6 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 else
 	echo "Disabling SSL support."
 	> /etc/httpd/conf.d/ssl.conf
-
-	sed -i \
-		-e 's~^NameVirtualHost \*:443$~#NameVirtualHost \*:443~g' \
-		-e 's~^Include ${OPTS_APP_HOME_DIR}/vhost-ssl.conf$~#Include ${OPTS_APP_HOME_DIR}/vhost-ssl.conf~g' \
-		/etc/httpd/conf/httpd.conf
 fi
 
 # Set the service user / service group user

--- a/etc/services-config/httpd/conf.d/ssl.conf
+++ b/etc/services-config/httpd/conf.d/ssl.conf
@@ -71,152 +71,158 @@ SSLCryptoDevice builtin
 ## SSL Virtual Host Context
 ##
 
-<VirtualHost _default_:404>
+#<VirtualHost _default_:443>
+#
+## General setup for the virtual host, inherited from global configuration
+##DocumentRoot "/var/www/html"
+##ServerName www.example.com:443
+#
+## Use separate log files for the SSL virtual host; note that LogLevel
+## is not inherited from httpd.conf.
+#ErrorLog logs/ssl_error_log
+#TransferLog logs/ssl_access_log
+#LogLevel warn
+#
+##   SSL Engine Switch:
+##   Enable/Disable SSL for this virtual host.
+#SSLEngine on
+#
+##   SSL Protocol support:
+## List the enable protocol levels with which clients will be able to
+## connect.  Disable SSLv2 access by default:
+#SSLProtocol all -SSLv2
+#
+##   SSL Cipher Suite:
+## List the ciphers that the client is permitted to negotiate.
+## See the mod_ssl documentation for a complete list.
+#SSLCipherSuite DEFAULT:!EXP:!SSLv2:!DES:!IDEA:!SEED:+3DES
+#
+##   Server Certificate:
+## Point SSLCertificateFile at a PEM encoded certificate.  If
+## the certificate is encrypted, then you will be prompted for a
+## pass phrase.  Note that a kill -HUP will prompt again.  A new
+## certificate can be generated using the genkey(1) command.
+#SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+#
+##   Server Private Key:
+##   If the key is not combined with the certificate, use this
+##   directive to point at the key file.  Keep in mind that if
+##   you've both a RSA and a DSA private key you can configure
+##   both in parallel (to also allow the use of DSA ciphers, etc.)
+#SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+#
+##   Server Certificate Chain:
+##   Point SSLCertificateChainFile at a file containing the
+##   concatenation of PEM encoded CA certificates which form the
+##   certificate chain for the server certificate. Alternatively
+##   the referenced file can be the same as SSLCertificateFile
+##   when the CA certificates are directly appended to the server
+##   certificate for convinience.
+##SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
+#
+##   Certificate Authority (CA):
+##   Set the CA certificate verification path where to find CA
+##   certificates for client authentication or alternatively one
+##   huge file containing all of them (file must be PEM encoded)
+##SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+#
+##   Client Authentication (Type):
+##   Client certificate verification type and depth.  Types are
+##   none, optional, require and optional_no_ca.  Depth is a
+##   number which specifies how deeply to verify the certificate
+##   issuer chain before deciding the certificate is not valid.
+##SSLVerifyClient require
+##SSLVerifyDepth  10
+#
+##   Access Control:
+##   With SSLRequire you can do per-directory access control based
+##   on arbitrary complex boolean expressions containing server
+##   variable checks and other lookup directives.  The syntax is a
+##   mixture between C and Perl.  See the mod_ssl documentation
+##   for more details.
+##<Location />
+##SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+##            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+##            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+##            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+##            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+##           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+##</Location>
+#
+##   SSL Engine Options:
+##   Set various options for the SSL engine.
+##   o FakeBasicAuth:
+##     Translate the client X.509 into a Basic Authorisation.  This means that
+##     the standard Auth/DBMAuth methods can be used for access control.  The
+##     user name is the `one line' version of the client's X.509 certificate.
+##     Note that no password is obtained from the user. Every entry in the user
+##     file needs this password: `xxj31ZMTZzkVA'.
+##   o ExportCertData:
+##     This exports two additional environment variables: SSL_CLIENT_CERT and
+##     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+##     server (always existing) and the client (only existing when client
+##     authentication is used). This can be used to import the certificates
+##     into CGI scripts.
+##   o StdEnvVars:
+##     This exports the standard SSL/TLS related `SSL_*' environment variables.
+##     Per default this exportation is switched off for performance reasons,
+##     because the extraction step is an expensive operation and is usually
+##     useless for serving static content. So one usually enables the
+##     exportation for CGI and SSI requests only.
+##   o StrictRequire:
+##     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+##     under a "Satisfy any" situation, i.e. when it applies access is denied
+##     and no other module can change it.
+##   o OptRenegotiate:
+##     This enables optimized SSL connection renegotiation handling when SSL
+##     directives are used in per-directory context. 
+##SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+#<Files ~ "\.(cgi|shtml|phtml|php3?)$">
+#    SSLOptions +StdEnvVars
+#</Files>
+#<Directory "/var/www/cgi-bin">
+#    SSLOptions +StdEnvVars
+#</Directory>
+#
+##   SSL Protocol Adjustments:
+##   The safe and default but still SSL/TLS standard compliant shutdown
+##   approach is that mod_ssl sends the close notify alert but doesn't wait for
+##   the close notify alert from client. When you need a different shutdown
+##   approach you can use one of the following variables:
+##   o ssl-unclean-shutdown:
+##     This forces an unclean shutdown when the connection is closed, i.e. no
+##     SSL close notify alert is send or allowed to received.  This violates
+##     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+##     this when you receive I/O errors because of the standard approach where
+##     mod_ssl sends the close notify alert.
+##   o ssl-accurate-shutdown:
+##     This forces an accurate shutdown when the connection is closed, i.e. a
+##     SSL close notify alert is send and mod_ssl waits for the close notify
+##     alert of the client. This is 100% SSL/TLS standard compliant, but in
+##     practice often causes hanging connections with brain-dead browsers. Use
+##     this only for browsers where you know that their SSL implementation
+##     works correctly. 
+##   Notice: Most problems of broken clients are also related to the HTTP
+##   keep-alive facility, so you usually additionally want to disable
+##   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+##   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+##   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+##   "force-response-1.0" for this.
+#SetEnvIf User-Agent ".*MSIE.*" \
+#         nokeepalive ssl-unclean-shutdown \
+#         downgrade-1.0 force-response-1.0
+#
+##   Per-Server Logging:
+##   The home of a custom SSL log file. Use this when you want a
+##   compact non-error SSL logfile on a virtual host basis.
+#CustomLog logs/ssl_request_log \
+#          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+#
+#</VirtualHost>                                  
+#
 
-# General setup for the virtual host, inherited from global configuration
-#DocumentRoot "/var/www/html"
-#ServerName www.example.com:443
-
-# Use separate log files for the SSL virtual host; note that LogLevel
-# is not inherited from httpd.conf.
-ErrorLog logs/ssl_error_log
-TransferLog logs/ssl_access_log
-LogLevel warn
-
-#   SSL Engine Switch:
-#   Enable/Disable SSL for this virtual host.
-SSLEngine on
-
-#   SSL Protocol support:
-# List the enable protocol levels with which clients will be able to
-# connect.  Disable SSLv2 access by default:
-SSLProtocol all -SSLv2
-
-#   SSL Cipher Suite:
-# List the ciphers that the client is permitted to negotiate.
-# See the mod_ssl documentation for a complete list.
-SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
-
-#   Server Certificate:
-# Point SSLCertificateFile at a PEM encoded certificate.  If
-# the certificate is encrypted, then you will be prompted for a
-# pass phrase.  Note that a kill -HUP will prompt again.  A new
-# certificate can be generated using the genkey(1) command.
-SSLCertificateFile /etc/pki/tls/certs/localhost.crt
-
-#   Server Private Key:
-#   If the key is not combined with the certificate, use this
-#   directive to point at the key file.  Keep in mind that if
-#   you've both a RSA and a DSA private key you can configure
-#   both in parallel (to also allow the use of DSA ciphers, etc.)
-SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
-
-#   Server Certificate Chain:
-#   Point SSLCertificateChainFile at a file containing the
-#   concatenation of PEM encoded CA certificates which form the
-#   certificate chain for the server certificate. Alternatively
-#   the referenced file can be the same as SSLCertificateFile
-#   when the CA certificates are directly appended to the server
-#   certificate for convinience.
-#SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
-
-#   Certificate Authority (CA):
-#   Set the CA certificate verification path where to find CA
-#   certificates for client authentication or alternatively one
-#   huge file containing all of them (file must be PEM encoded)
-#SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
-
-#   Client Authentication (Type):
-#   Client certificate verification type and depth.  Types are
-#   none, optional, require and optional_no_ca.  Depth is a
-#   number which specifies how deeply to verify the certificate
-#   issuer chain before deciding the certificate is not valid.
-#SSLVerifyClient require
-#SSLVerifyDepth  10
-
-#   Access Control:
-#   With SSLRequire you can do per-directory access control based
-#   on arbitrary complex boolean expressions containing server
-#   variable checks and other lookup directives.  The syntax is a
-#   mixture between C and Perl.  See the mod_ssl documentation
-#   for more details.
-#<Location />
-#SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
-#            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
-#            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
-#            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
-#            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
-#           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
-#</Location>
-
-#   SSL Engine Options:
-#   Set various options for the SSL engine.
-#   o FakeBasicAuth:
-#     Translate the client X.509 into a Basic Authorisation.  This means that
-#     the standard Auth/DBMAuth methods can be used for access control.  The
-#     user name is the `one line' version of the client's X.509 certificate.
-#     Note that no password is obtained from the user. Every entry in the user
-#     file needs this password: `xxj31ZMTZzkVA'.
-#   o ExportCertData:
-#     This exports two additional environment variables: SSL_CLIENT_CERT and
-#     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
-#     server (always existing) and the client (only existing when client
-#     authentication is used). This can be used to import the certificates
-#     into CGI scripts.
-#   o StdEnvVars:
-#     This exports the standard SSL/TLS related `SSL_*' environment variables.
-#     Per default this exportation is switched off for performance reasons,
-#     because the extraction step is an expensive operation and is usually
-#     useless for serving static content. So one usually enables the
-#     exportation for CGI and SSI requests only.
-#   o StrictRequire:
-#     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
-#     under a "Satisfy any" situation, i.e. when it applies access is denied
-#     and no other module can change it.
-#   o OptRenegotiate:
-#     This enables optimized SSL connection renegotiation handling when SSL
-#     directives are used in per-directory context. 
-#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
-<Files ~ "\.(cgi|shtml|phtml|php3?)$">
-    SSLOptions +StdEnvVars
-</Files>
-<Directory "/var/www/cgi-bin">
-    SSLOptions +StdEnvVars
-</Directory>
-
-#   SSL Protocol Adjustments:
-#   The safe and default but still SSL/TLS standard compliant shutdown
-#   approach is that mod_ssl sends the close notify alert but doesn't wait for
-#   the close notify alert from client. When you need a different shutdown
-#   approach you can use one of the following variables:
-#   o ssl-unclean-shutdown:
-#     This forces an unclean shutdown when the connection is closed, i.e. no
-#     SSL close notify alert is send or allowed to received.  This violates
-#     the SSL/TLS standard but is needed for some brain-dead browsers. Use
-#     this when you receive I/O errors because of the standard approach where
-#     mod_ssl sends the close notify alert.
-#   o ssl-accurate-shutdown:
-#     This forces an accurate shutdown when the connection is closed, i.e. a
-#     SSL close notify alert is send and mod_ssl waits for the close notify
-#     alert of the client. This is 100% SSL/TLS standard compliant, but in
-#     practice often causes hanging connections with brain-dead browsers. Use
-#     this only for browsers where you know that their SSL implementation
-#     works correctly. 
-#   Notice: Most problems of broken clients are also related to the HTTP
-#   keep-alive facility, so you usually additionally want to disable
-#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
-#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
-#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
-#   "force-response-1.0" for this.
-SetEnvIf User-Agent ".*MSIE.*" \
-         nokeepalive ssl-unclean-shutdown \
-         downgrade-1.0 force-response-1.0
-
-#   Per-Server Logging:
-#   The home of a custom SSL log file. Use this when you want a
-#   compact non-error SSL logfile on a virtual host basis.
-CustomLog logs/ssl_request_log \
-          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
-
-</VirtualHost>                                  
-
+#
+# Custom SSL configuration
+#
+NameVirtualHost *:443
+Include ${APP_HOME_DIR}/vhost-ssl.conf

--- a/etc/services-config/httpd/conf/httpd.conf
+++ b/etc/services-config/httpd/conf/httpd.conf
@@ -1014,5 +1014,6 @@ BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 #
 Options -Indexes
 Listen 8443
+NameVirtualHost *:80
 NameVirtualHost *:8443
 Include ${APP_HOME_DIR}/vhost.conf

--- a/etc/services-config/httpd/conf/httpd.conf
+++ b/etc/services-config/httpd/conf/httpd.conf
@@ -631,7 +631,7 @@ ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
 #AddIcon /icons/uuencoded.gif .uu
 #AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
 #AddIcon /icons/tex.gif .tex
-#AddIcon /icons/bomb.gif core
+#AddIcon /icons/bomb.gif /core
 
 #AddIcon /icons/back.gif ..
 #AddIcon /icons/hand.right.gif README
@@ -919,12 +919,12 @@ BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 # with the URL of http://servername/server-status
 # Change the ".example.com" to match your domain to enable.
 #
-#<Location /server-status>
-#    SetHandler server-status
-#    Order deny,allow
-#    Deny from all
-#    Allow from .example.com
-#</Location>
+<Location /_httpdstatus>
+    SetHandler server-status
+    Order deny,allow
+    Deny from all
+    Allow from localhost 127.0.0.1
+</Location>
 
 #
 # Allow remote server configuration reports, with the URL of
@@ -1014,15 +1014,5 @@ BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 #
 Options -Indexes
 Listen 8443
-NameVirtualHost *:80
 NameVirtualHost *:8443
-#NameVirtualHost *:443
 Include ${APP_HOME_DIR}/vhost.conf
-#Include ${APP_HOME_DIR}/vhost-ssl.conf
-
-<Location /server-status>
-    SetHandler server-status
-    Order deny,allow
-    Deny from all
-    Allow from localhost 127.0.0.1
-</Location>

--- a/etc/services-config/httpd/conf/httpd.conf.default
+++ b/etc/services-config/httpd/conf/httpd.conf.default
@@ -630,7 +630,7 @@ AddIcon /icons/dvi.gif .dvi
 AddIcon /icons/uuencoded.gif .uu
 AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
 AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
+AddIcon /icons/bomb.gif /core
 
 AddIcon /icons/back.gif ..
 AddIcon /icons/hand.right.gif README

--- a/etc/services-config/supervisor/supervisord.conf
+++ b/etc/services-config/supervisor/supervisord.conf
@@ -33,7 +33,7 @@ stdout_events_enabled = true
 
 [program:httpd]
 priority = 100
-command = /bin/bash -c "%(ENV_HTTPD)s -c \"ErrorLog /dev/stdout\" -DFOREGROUND"
+command = /bin/bash -c "/bin/sleep 2 && %(ENV_HTTPD)s -c \"ErrorLog /dev/stdout\" -DFOREGROUND"
 redirect_stderr = true
 stdout_logfile = /var/log/httpd/error_log
 stdout_events_enabled = true


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-apache-php/issues/54

To access the Apache ServerStatus page you can use the supplied elinks browser as following - assuming the container has been named `apache-php.app-1.1.1`.

```
docker exec -it apache-php.app-1.1.1 elinks http://app-1/_httpdstatus
```

- Refactored the configuration so that HTTPS configuration is all loaded from `/etc/httpd/conf.d/ssl.conf` instead of having it alongside the HTTP configuration and having to comment it out and ucomment it from the initialisation script when required.

- Commented out the default SSL VirtualHost instead of using a non-standard port to prevent it being loaded unnecessarily.