### PR TITLE
CLOSES #109: Disable TRACE method by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN { \
 		echo '# Custom configuration'; \
 		echo '#'; \
 		echo 'Options -Indexes'; \
+		echo 'TraceEnable Off'; \
 		echo 'Listen 8443'; \
 		echo 'NameVirtualHost *:80'; \
 		echo 'NameVirtualHost *:8443'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN sed -i \
 	-e 's~^NameVirtualHost \(.*\)$~#NameVirtualHost \1~g' \
 	-e 's~^User .*$~User ${APACHE_RUN_USER}~g' \
 	-e 's~^Group .*$~Group ${APACHE_RUN_GROUP}~g' \
+	-e 's~^DocumentRoot \(.*\)$~#DocumentRoot \1~g' \
 	/etc/httpd/conf/httpd.conf
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- Prevent startup errors when using a volume mapping that results in /var/www/html directory being unavailable and causing the default DocumentRoot path to become invalid resulting in a Syntax Error.
- Disable TRACE method by default. It can be specifically enabled if in the VirtualHost if required for debugging.