### PR TITLE
CLOSES #184: Adds {{HOSTNAME}} placeholder replacement for SERVICE_UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,11 @@ To set the timezone for the UK and account for British Summer Time you would use
 
 ##### SERVICE_UID
 
-The ```SERVICE_UID``` environmental variable is used to set a response header named ```X-Service-Uid``` that lets you identify the container that is serving the content. This is useful when you have many containers running on a single host using different ports or if you are running a cluster and need to identify which host the content is served from. The default value is set to the Service Unit's App Group Name, Local ID and Instance ID.
+The ```SERVICE_UID``` environmental variable is used to set a response header named ```X-Service-Uid``` that lets you identify the container that is serving the content. This is useful when you have many containers running on a single host using different ports or if you are running a cluster and need to identify which host the content is served from. If the value contains the placeholder `{{HOSTNAME}}` it will be replaced with the system `hostname` value; by default this is the container id but the hostname can be modified using the `--hostname` docker create|run parameter.
 
 ```
 ...
-  --env "SERVICE_UID=app-1.1.1" \
+  --env "SERVICE_UID={{HOSTNAME}}" \
 ...
 ```
 

--- a/etc/services-config/supervisor/supervisord.d/httpd-wrapper.conf
+++ b/etc/services-config/supervisor/supervisord.d/httpd-wrapper.conf
@@ -1,6 +1,6 @@
 [program:httpd-wrapper]
 priority = 100
-command = bash -c "while true; do sleep 0.1; [ -e /tmp/httpd-bootstrap.lock ] || break; done; exec %(ENV_HTTPD)s -c \"ErrorLog /dev/stdout\" -DFOREGROUND -D %(ENV_APACHE_OPERATING_MODE)s"
+command = bash -c "while true; do sleep 0.1; [ -e /tmp/httpd-bootstrap.lock ] || break; done; exec env SERVICE_UID=\"${SERVICE_UID//\{\{HOSTNAME\}\}/$(hostname)}\" %(ENV_HTTPD)s -c \"ErrorLog /dev/stdout\" -DFOREGROUND -D %(ENV_APACHE_OPERATING_MODE)s"
 startsecs = 0
 autorestart = true
 redirect_stderr = true

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -276,6 +276,24 @@ get_apache_public_directory ()
 	printf "%s" "${VALUE}"
 }
 
+get_service_uid ()
+{
+	local DEFAULT_VALUE="${1:-}"
+	local HOST_NAME="$(
+		hostname
+	)"
+	local VALUE="${SERVICE_UID}"
+
+	if [[ -z ${VALUE} ]] && [[ -n ${DEFAULT_VALUE} ]]; then
+		VALUE="${DEFAULT_VALUE}"
+	else
+		# Replace {{HOSTNAME}} with system hostname
+		VALUE="${VALUE//\{\{HOSTNAME\}\}/${HOST_NAME}}"
+	fi
+
+	printf "%s" "${VALUE}"
+}
+
 get_ssl_certificate_fingerprint ()
 {
 	local DIGEST=${1:-sha1}
@@ -348,6 +366,9 @@ OPTS_APACHE_RUN_USER="${APACHE_RUN_USER:-${DEFAULT_APACHE_USER}}"
 OPTS_APACHE_SERVER_ALIAS="${APACHE_SERVER_ALIAS:-}"
 OPTS_APACHE_SERVER_NAME="${APACHE_SERVER_NAME:-$(hostname)}"
 OPTS_APACHE_SYSTEM_USER="${APACHE_SYSTEM_USER:-${DEFAULT_SYSTEM_USER}}"
+OPTS_SERVICE_UID="$(
+	get_service_uid
+)"
 
 # Generate SSL certificate.
 if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
@@ -523,6 +544,7 @@ cat <<-EOT
 	document root : ${OPTS_APACHE_DOCUMENT_ROOT} (${APACHE_DOCUMENT_ROOT_FILE_SYSTEM})
 	modules enabled :
 	${APACHE_MODULES_ENABLED}${SSL_CRT_FINGERPRINT_DETAILS}
+	service uid : ${OPTS_SERVICE_UID}
 	--------------------------------------------------------------------------------
 	${TIMER_TOTAL}
 


### PR DESCRIPTION
Resolves #184 
- The placeholder `{{HOSTNAME}}` will be replaced with the system (container) hostname when used in the value of the environment variable `SERVICE_UID`.
