### PR TITLE
CLOSES #200: Adds improved httpd configuration file handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -226,14 +226,6 @@ RUN mkdir -p -m 750 ${PACKAGE_PATH}
 ADD var/www/app ${PACKAGE_PATH}
 RUN find ${PACKAGE_PATH} -name '*.gitkeep' -type f -delete \
 	&& $(\
-		if [[ -d ${PACKAGE_PATH}/etc/httpd/conf.d ]]; then \
-			for file_path in ${PACKAGE_PATH}/etc/httpd/conf.d/*.conf; do \
-				cp -f ${file_path} \
-					/etc/services-config/httpd/conf.d/${file_path##*/}; \
-			done; \
-		fi \
-	) \
-	&& $(\
 		if [[ -f /usr/share/php-pecl-apc/apc.php ]]; then \
 			cp \
 				/usr/share/php-pecl-apc/apc.php \

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -312,12 +312,27 @@ get_ssl_certificate_fingerprint ()
 	printf "%s" "${VALUE}"
 }
 
-parse_php_ini_scan_files ()
+load_httpd_conf_scan_files ()
 {
 	local FILE_PATH
 	local PACKAGE_PATH="${1:-}"
 
 	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+		for FILE_PATH in "${PACKAGE_PATH}"/etc/httpd/conf.d/*.conf; do
+			cat  \
+				"${FILE_PATH}" \
+			> "/etc/services-config/httpd/conf.d/${FILE_PATH##*/}"
+		done
+	fi
+}
+
+load_php_ini_scan_files ()
+{
+	local FILE_PATH
+	local PACKAGE_PATH="${1:-}"
+
+	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+		# Replace environment variables to support fcgid php-wrapper
 		for FILE_PATH in "${PACKAGE_PATH}"/etc/php.d/*.ini; do
 			printf -- \
 				'%s' \
@@ -390,10 +405,11 @@ OPTS_SERVICE_UID="$(
 	get_service_uid
 )"
 
-# Parse PHP configuration files - variables are replaced with text values.
-# This is neccessary for use in fcgid php-wrapper.
-parse_php_ini_scan_files
-parse_php_ini_scan_files "${PACKAGE_PATH}"
+# Load app package Apache configuration files.
+load_httpd_conf_scan_files "${PACKAGE_PATH}"
+
+# Load app package PHP configuration files.
+load_php_ini_scan_files "${PACKAGE_PATH}"
 
 # Generate SSL certificate.
 if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -528,9 +528,23 @@ APACHE_MODULES_ENABLED=$(
 # Enable/Disable SSL support
 if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 	echo "Enabling SSL support."
-	cat /etc/httpd/conf.d/ssl.conf.off > /etc/httpd/conf.d/ssl.conf
+	cat \
+		/etc/httpd/conf.d/ssl.conf.off \
+		> /etc/httpd/conf.d/ssl.conf
+
+	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off ]]; then
+		mv \
+			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off \
+			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf
+	fi
 else
 	> /etc/httpd/conf.d/ssl.conf
+
+	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf ]]; then
+		mv \
+			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf \
+			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off
+	fi
 fi
 
 # Set ownership for fcgid php-wrapper and socket if necessary

--- a/var/www/app/etc/httpd/conf.d/50-fcgid.conf
+++ b/var/www/app/etc/httpd/conf.d/50-fcgid.conf
@@ -1,4 +1,22 @@
 <IfModule mod_fcgid.c>
+    # Use FastCGI to process .fcg .fcgi .fpl & .php scripts
+    AddHandler fcgid-script fcg fcgi fpl php
+    AddType text/html php
+
+    # Add index.php to the list of files that will be served as directory
+    # indexes.
+    DirectoryIndex index.php
+
+    FcgidMaxProcesses 10
+    FcgidMaxRequestsPerProcess 10000
+    FcgidIOTimeout 360
+    FcgidIdleTimeout 1800
+    FcgidFixPathinfo 1
+    FcgidMaxRequestLen 157286400
+
+    # Enable Basic Authentication
+    FcgidPassHeader Authorization
+
     # Docker Linked MySQL database connection details
     FcgidInitialEnv DB_MYSQL_PORT_3306_TCP_ADDR ${DB_MYSQL_PORT_3306_TCP_ADDR}
     FcgidInitialEnv DB_MYSQL_PORT_3306_TCP_PORT ${DB_MYSQL_PORT_3306_TCP_PORT}


### PR DESCRIPTION
Resolves #200 
- Adds app package fcgid configuration. Used when build with fcgid support.
- Adds loading of Apache app package configuration files into the bootstrap.
- Removes a now redundant image build step.
- Adds enable/disable of the SSL VirtualHost configuration into the bootstrap.
