### PR TITLE
CLOSES #231: Updates source to release centos-6-1.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packages
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.7.0
+FROM jdeathe/centos-ssh:centos-6-1.7.2
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 

--- a/environment.mk
+++ b/environment.mk
@@ -26,7 +26,7 @@ DOCKER_RESTART_POLICY ?= always
 NO_CACHE ?= false
 
 # Directory path for release packages
-PACKAGE_PATH ?= ./packages/jdeathe
+DIST_PATH ?= ./dist
 
 # ------------------------------------------------------------------------------
 # Application container configuration


### PR DESCRIPTION
Resolves #231
- Updates source to release centos-6-1.7.2.
- Replaces `PACKAGE_PATH` with `DIST_PATH` in Makefile. The package output directory created will be `./dist` instead of `./packages/jdeathe`.
