### PR TITLE
CLOSES #239: Simplify self-signed certificate output in bootstrap

### DIFF
--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -346,17 +346,9 @@ function make_self_signed_certificate ()
 		-newkey rsa:2048 \
 		-days 365 \
 		-subj "/C=${C}/ST=${ST}/L=${L}/O=${O}/CN=${CN}" \
-		-keyout /tmp/localhost.key \
-		-out /tmp/localhost.crt
+		-keyout /etc/services-config/ssl/certs/localhost.crt \
+		-out /etc/services-config/ssl/certs/localhost.crt
 
-	# Combine the key and certificate
-	cat \
-		/tmp/localhost.key \
-		/tmp/localhost.crt \
-	> /etc/services-config/ssl/certs/localhost.crt
-
-	rm -f \
-		/tmp/localhost.{crt,key}
 }
 
 function set_apache_enable_sendfile ()


### PR DESCRIPTION
Resolves #239
- Removes unnecessary steps to combine the self-signed certificate and key.
