### PR TITLE
ISSUE #240: Adds fix to allow installation on Atomic Hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ LABEL \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh-apache-php:centos-6-${RELEASE_VERSION} \
-/sbin/scmi install \
+/usr/sbin/scmi install \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-6-${RELEASE_VERSION}" \
@@ -296,7 +296,7 @@ jdeathe/centos-ssh-apache-php:centos-6-${RELEASE_VERSION} \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh-apache-php:centos-6-${RELEASE_VERSION} \
-/sbin/scmi uninstall \
+/usr/sbin/scmi uninstall \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-6-${RELEASE_VERSION}" \

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ docker exec -it apache-php.pool-1.1.1 apachectl -h
 
 ### Running
 
-To run the a docker container from this image you can use the standard docker commands. Alternatively, you can use the embedded (Service Container Manager Interface) [scmi](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/usr/sbin/scmi) that is included in the image since `centos-6-1.7.0` or, if you have a checkout of the [source repository](https://github.com/jdeathe/centos-ssh-apache-php), and have make installed the Makefile provides targets to build, install, start, stop etc. where environment variables can be used to configure the container options and set custom docker run parameters.
+To run the a docker container from this image you can use the standard docker commands. Alternatively, you can use the embedded (Service Container Manager Interface) [scmi](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/usr/sbin/scmi) that is included in the image since `centos-6-1.7.2` or, if you have a checkout of the [source repository](https://github.com/jdeathe/centos-ssh-apache-php), and have make installed the Makefile provides targets to build, install, start, stop etc. where environment variables can be used to configure the container options and set custom docker run parameters.
 
 #### SCMI Installation Examples
 
@@ -85,10 +85,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2 \
   /sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.2 \
     --name=apache-php.pool-1.1.1
 ```
 
@@ -101,10 +101,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2 \
   /sbin/scmi uninstall \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.2 \
     --name=apache-php.pool-1.1.1
 ```
 
@@ -117,10 +117,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2 \
   /sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.2 \
     --name=apache-php.pool-1.1.1 \
     --manager=systemd \
     --register \
@@ -134,7 +134,7 @@ If your docker host has systemd, fleetd (and optionally etcd) installed then `sc
 
 ##### SCMI Image Information
 
-Since release `centos-6-1.7.0` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
+Since release `centos-6-1.7.2` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
 
 To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
 
@@ -142,7 +142,7 @@ To see detailed information about the image run `scmi` with the `--info` option.
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.7.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.7.2
   ) --info"
 ```
 
@@ -152,7 +152,7 @@ To perform an installation using the docker name `apache-php.pool-1.2.1` simply 
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.7.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.7.2
   ) --name=apache-php.pool-1.2.1"
 ```
 
@@ -162,7 +162,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.uninstall}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.7.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.7.2
   ) --name=apache-php.pool-1.2.1"
 ```
 
@@ -175,7 +175,7 @@ To see detailed information about the image run `scmi` with the `--info` option.
 ```
 $ sudo -E atomic install \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2 \
   --info
 ```
 
@@ -184,14 +184,14 @@ To perform an installation using the docker name `apache-php.pool-1.3.1` simply 
 ```
 $ sudo -E atomic install \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2
 ```
 
 Alternatively, you could use the `scmi` options `--name` or `-n` for naming the container.
 
 ```
 $ sudo -E atomic install \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2 \
   --name apache-php.pool-1.3.1
 ```
 
@@ -200,7 +200,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 ```
 $ sudo -E atomic uninstall \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.7.0
+  jdeathe/centos-ssh-apache-php:centos-6-1.7.2
 ```
 
 #### Environment Variables


### PR DESCRIPTION
Resolves #240 
- Adds correct path to `scmi` in image metadata to allow `atomic install` to complete successfully.
