### PR TITLE
CLOSES #269: Adds updated image tag pattern rules.

### DIFF
--- a/environment.mk
+++ b/environment.mk
@@ -5,8 +5,8 @@ DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$
-DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
+DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$
+DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -5,8 +5,8 @@ DOCKER_USER=jdeathe
 DOCKER_IMAGE_NAME=centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$'
-DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|7-2).[0-9]+.[0-9]+$'
+DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$'
+DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$'
 
 # -----------------------------------------------------------------------------
 # Variables


### PR DESCRIPTION
Resolves #269 - Patched back #267
- Adds updated image tag pattern rules required for the new `centos-6-httpd24u-php56u` based tags.
