### PR TITLE
Release changes for 2.0.0 - Rev1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1 \
   /usr/sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.8.0 \
+    --tag=centos-6-1.8.1 \
     --name=apache-php.pool-1.1.1
 ```
 
@@ -109,10 +109,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1 \
   /usr/sbin/scmi uninstall \
     --chroot=/media/root \
-    --tag=centos-6-1.8.0 \
+    --tag=centos-6-1.8.1 \
     --name=apache-php.pool-1.1.1
 ```
 
@@ -125,10 +125,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1 \
   /usr/sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.8.0 \
+    --tag=centos-6-1.8.1 \
     --name=apache-php.pool-1.1.1 \
     --manager=systemd \
     --register \
@@ -147,11 +147,11 @@ Since release `centos-6-1.7.2` the install template has been added to the image 
 To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
 
 ```
-$ docker pull jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+$ docker pull jdeathe/centos-ssh-apache-php:centos-6-1.8.1
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.8.1
   ) --info"
 ```
 
@@ -161,7 +161,7 @@ To perform an installation using the docker name `apache-php.pool-1.2.1` simply 
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.8.1
   ) --name=apache-php.pool-1.2.1"
 ```
 
@@ -171,7 +171,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.uninstall}}" \
-    jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+    jdeathe/centos-ssh-apache-php:centos-6-1.8.1
   ) --name=apache-php.pool-1.2.1"
 ```
 
@@ -184,7 +184,7 @@ To see detailed information about the image run `scmi` with the `--info` option.
 ```
 $ sudo -E atomic install \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1 \
   --info
 ```
 
@@ -193,14 +193,14 @@ To perform an installation using the docker name `apache-php.pool-1.3.1` simply 
 ```
 $ sudo -E atomic install \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1
 ```
 
 Alternatively, you could use the `scmi` options `--name` or `-n` for naming the container.
 
 ```
 $ sudo -E atomic install \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0 \
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1 \
   --name apache-php.pool-1.3.1
 ```
 
@@ -209,7 +209,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 ```
 $ sudo -E atomic uninstall \
   -n apache-php.pool-1.3.1 \
-  jdeathe/centos-ssh-apache-php:centos-6-1.8.0
+  jdeathe/centos-ssh-apache-php:centos-6-1.8.1
 ```
 
 #### Environment Variables

--- a/environment.mk
+++ b/environment.mk
@@ -5,8 +5,8 @@ DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$
-DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
+DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$
+DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -5,8 +5,8 @@ DOCKER_USER=jdeathe
 DOCKER_IMAGE_NAME=centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$'
-DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|7-2).[0-9]+.[0-9]+$'
+DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$'
+DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$'
 
 # -----------------------------------------------------------------------------
 # Variables


### PR DESCRIPTION
- Adds updated image tag pattern rules required for the new `centos-6-httpd24u-php56u` based tags.
- Adds updated README SCMI instructions using a version that will include the updated tag pattern rules.
