### PR TITLE
CLOSES #283: Replaces mv operations with cat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,9 +127,9 @@ RUN { \
 # -----------------------------------------------------------------------------
 # Disable the SSL support by default
 # -----------------------------------------------------------------------------
-RUN mv \
+RUN cat \
 		/etc/httpd/conf.d/ssl.conf \
-		/etc/httpd/conf.d/ssl.conf.off \
+		> /etc/httpd/conf.d/ssl.conf.off \
 	&& touch \
 		/etc/httpd/conf.d/ssl.conf \
 	&& chmod 444 \

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -666,17 +666,15 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 		> /etc/httpd/conf.d/ssl.conf
 
 	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off ]]; then
-		mv \
+		cat \
 			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off \
-			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf
+			> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
 	fi
 else
 	> /etc/httpd/conf.d/ssl.conf
 
 	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf ]]; then
-		mv \
-			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf \
-			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off
+		> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
 	fi
 fi
 


### PR DESCRIPTION
Resolves #283 - patch back #280 

- Replaces mv operations with cat to work-around OverlayFS limitations in CentOS-7.