### PR TITLE
CLOSES #287: Update source to centos-6-1.7.5 release tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+## centos-6-httpd24u-php56u
+
+Summary of release changes for Version 2.
+
+CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
+
+### 2.0.0 - 2016-10-27
+
+- Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.7.3
+FROM jdeathe/centos-ssh:1.7.5
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,13 +108,6 @@ RUN sed -i \
 	/etc/httpd/conf.modules.d/00-proxy.conf
 
 # -----------------------------------------------------------------------------
-# Disable the default SSL Virtual Host
-# -----------------------------------------------------------------------------
-RUN sed -i \
-	-e '/<VirtualHost _default_:443>/,/#<\/VirtualHost>/ s~^~#~' \
-	/etc/httpd/conf.d/ssl.conf
-
-# -----------------------------------------------------------------------------
 # Custom Apache configuration
 # -----------------------------------------------------------------------------
 RUN { \
@@ -138,9 +131,12 @@ RUN { \
 	} >> /etc/httpd/conf/httpd.conf
 
 # -----------------------------------------------------------------------------
-# Disable the SSL support by default
+# Disable SSL + the default SSL Virtual Host
 # -----------------------------------------------------------------------------
-RUN cat \
+RUN sed -i \
+		-e '/<VirtualHost _default_:443>/,/#<\/VirtualHost>/ s~^~#~' \
+		/etc/httpd/conf.d/ssl.conf \
+	&& cat \
 		/etc/httpd/conf.d/ssl.conf \
 		> /etc/httpd/conf.d/ssl.conf.off \
 	&& touch \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ Targets:
   start                     Start the container in the created state.
   stop                      Stop the container when in a running state.
   terminate                 Unpause, stop and remove the container.
+  test                      Run all test cases.
   unpause                   Unpause the container when in a paused state.
 
 Variables:
@@ -108,10 +109,15 @@ PREFIX_SUB_STEP_POSITIVE := $(shell \
 
 # Package prerequisites
 docker := $(shell \
-	type -p docker \
+	command -v docker \
 )
 xz := $(shell \
-	type -p xz \
+	command -v xz \
+)
+
+# Testing prerequisites
+shpec := $(shell \
+	command -v shpec \
 )
 
 # Used to test docker host is accessible
@@ -131,6 +137,7 @@ get-docker-info := $(shell \
 	_require-docker-image-tag \
 	_require-docker-release-tag \
 	_require-package-path \
+	_test-prerequisites \
 	_usage \
 	all \
 	build \
@@ -155,6 +162,7 @@ get-docker-info := $(shell \
 	start \
 	stop \
 	terminate \
+	test \
 	unpause
 
 _prerequisites:
@@ -244,6 +252,11 @@ _require-package-path:
 		echo "$(PREFIX_STEP_NEGATIVE)Undefined DIST_PATH"; \
 		exit 1; \
 	fi
+
+_test-prerequisites:
+ifeq ($(shpec),)
+	$(error "Please install shpec.")
+endif
 
 _usage:
 	@: $(info $(USAGE))
@@ -485,6 +498,13 @@ terminate: _prerequisites
 			exit 1; \
 		fi; \
 	fi
+
+test: _test-prerequisites
+	@ if [[ -z $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); fi;) ]]; then \
+		$(MAKE) build; \
+	fi;
+	@ echo "$(PREFIX_STEP)Functional test";
+	@ SHPEC_ROOT=$(SHPEC_ROOT) $(shpec);
 
 unpause: _prerequisites _require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP)Unpausing container"

--- a/Makefile
+++ b/Makefile
@@ -172,78 +172,78 @@ endif
 
 _require-docker-container:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
+		echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
-			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+		echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not-status-paused:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
-			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+		echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-created:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
+		echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-exited:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
-			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+		echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-paused:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
-			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+		echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-running:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
-			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
+		echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
+		exit 1; \
+	fi
 
 _require-docker-image-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		exit 1; \
+	fi
 
 _require-docker-release-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
+		exit 1; \
+	fi
 
 _require-package-path:
 	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP) Creating package directory"; \
-			mkdir -p $(DIST_PATH); \
-		fi; \
-		if [[ ! $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
-			exit 1; \
-		elif [[ -z $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP) Creating package directory"; \
+		mkdir -p $(DIST_PATH); \
+	fi; \
+	if [[ ! $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
+		exit 1; \
+	elif [[ -z $(DIST_PATH) ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
+		exit 1; \
+	fi
 
 _usage:
 	@: $(info $(USAGE))
@@ -254,79 +254,79 @@ all: _prerequisites | build images install start ps
 build: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 	@ if [[ $(NO_CACHE) == true ]]; then \
-			echo "$(PREFIX_SUB_STEP) Skipping cache"; \
-		fi
+		echo "$(PREFIX_SUB_STEP) Skipping cache"; \
+	fi
 	@ $(docker) build \
-			--no-cache=$(NO_CACHE) \
-			-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
-			.; \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Build complete"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Build error"; \
-			exit 1; \
-		fi
+		--no-cache=$(NO_CACHE) \
+		-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
+		.; \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Build complete"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) Build error"; \
+		exit 1; \
+	fi
 
 clean: _prerequisites | terminate rmi
 
 create: _prerequisites _require-docker-container-not
 	@ echo "$(PREFIX_STEP) Creating container"
 	@ set -x; \
-		$(docker) create \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) create \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container created"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container creation failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Container created"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container creation failed"; \
+		exit 1; \
+	fi
 
 dist: _prerequisites _require-docker-release-tag _require-package-path | pull
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Saving package"; \
+		echo "$(PREFIX_STEP) Saving package"; \
+		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
+	else \
+		echo "$(PREFIX_STEP) Saving package"; \
+		$(docker) save \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
+			$(xz) -9 > \
+				$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
+		if [[ $${?} -eq 0 ]]; then \
 			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
 		else \
-			echo "$(PREFIX_STEP) Saving package"; \
-			$(docker) save \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
-				$(xz) -9 > \
-					$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
-				if [[ $${?} -eq 0 ]]; then \
-					echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
-				else \
-					echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
-					exit 1; \
-				fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
+			exit 1; \
+		fi; \
+	fi
 
 distclean: _prerequisites _require-docker-release-tag _require-package-path | clean
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Deleting package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			find $($@_dist_path) \
-				-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
-				-delete; \
-			if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
-				exit 1; \
-			fi; \
+		echo "$(PREFIX_STEP) Deleting package"; \
+		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		find $($@_dist_path) \
+			-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
+			-delete; \
+		if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
 		else \
-			echo "$(PREFIX_STEP) Package cleanup skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP) Package cleanup skipped"; \
+	fi
 
 exec: _prerequisites
 	@ $(docker) exec -it $(DOCKER_NAME) $(filter-out $@, $(MAKECMDGOALS))
@@ -334,7 +334,7 @@ exec: _prerequisites
 
 images: _prerequisites
 	@ $(docker) images \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
 
 help: _usage
 
@@ -352,17 +352,17 @@ load: _prerequisites _require-docker-release-tag _require-package-path
 		$(DIST_PATH) \
 	))
 	@ echo "$(PREFIX_STEP) Loading image from package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
-			exit 1; \
-		else \
-			$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
-				$(docker) load; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
-		fi
+	echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+	if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
+		exit 1; \
+	else \
+		$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
+			$(docker) load; \
+		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
+	fi
 
 pause: _prerequisites _require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Pausing container"
@@ -372,14 +372,14 @@ pause: _prerequisites _require-docker-container-status-running
 pull: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Pulling image from registry"
 	@ $(docker) pull \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image pulled"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error pulling image"; \
-			exit 1; \
-		fi
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Image pulled"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) Error pulling image"; \
+		exit 1; \
+	fi
 
 ps: _prerequisites _require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
@@ -391,100 +391,100 @@ restart: _prerequisites _require-docker-container _require-docker-container-not-
 
 rm: _prerequisites _require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container removal skipped"; \
+		echo "$(PREFIX_STEP) Container removal skipped"; \
+	else \
+		echo "$(PREFIX_STEP) Removing container"; \
+		$(docker) rm -f $(DOCKER_NAME); \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
 		else \
-		  echo "$(PREFIX_STEP) Removing container"; \
-			$(docker) rm -f $(DOCKER_NAME); \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
+			exit 1; \
+		fi; \
+	fi
 
 rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
 	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
-			echo "$(PREFIX_STEP) Untagging image"; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
-			$(docker) rmi \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
-			if [[ $${?} -eq 0 ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Image untagged"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error untagging image"; \
-				exit 1; \
-			fi; \
+		echo "$(PREFIX_STEP) Untagging image"; \
+		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
+		$(docker) rmi \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
+		if [[ $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Image untagged"; \
 		else \
-			echo "$(PREFIX_STEP) Untagging image skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error untagging image"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP) Untagging image skipped"; \
+	fi
 
 run: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Running container"
 	@ set -x; \
-		$(docker) run \
-			--detach \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) run \
+		--detach \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container running"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container run failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Container running"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container run failed"; \
+		exit 1; \
+	fi
 
 start: _prerequisites _require-docker-container _require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
-			&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) start $(DOCKER_NAME) 1> /dev/null; \
-		fi
+		&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+		$(docker) start $(DOCKER_NAME) 1> /dev/null; \
+	fi
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container started"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container start failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP_POSITIVE) Container started"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container start failed"; \
+		exit 1; \
+	fi
 
 stop: _prerequisites _require-docker-container-not-status-paused _require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
-				exit 1; \
-			fi; \
-		fi
+		$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
+		else \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
+			exit 1; \
+		fi; \
+	fi
 
 terminate: _prerequisites
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container termination skipped"; \
+		echo "$(PREFIX_STEP) Container termination skipped"; \
+	else \
+		echo "$(PREFIX_STEP) Terminating container"; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_SUB_STEP) Unpausing container"; \
+			$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+			echo "$(PREFIX_SUB_STEP) Stopping container"; \
+			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP) Removing container"; \
+			$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
 		else \
-			echo "$(PREFIX_STEP) Terminating container"; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Unpausing container"; \
-				$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Stopping container"; \
-				$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Removing container"; \
-				$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
+			exit 1; \
+		fi; \
+	fi
 
 unpause: _prerequisites _require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP) Unpausing container"

--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ load: _prerequisites _require-docker-release-tag _require-package-path
 	else \
 		$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
 			$(docker) load; \
-		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
 		echo "$(PREFIX_SUB_STEP_POSITIVE)Image loaded"; \
 	fi
 
@@ -374,7 +374,7 @@ pull: _prerequisites _require-docker-image-tag
 	@ $(docker) pull \
 		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
 	if [[ $${?} -eq 0 ]]; then \
-		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
 		echo "$(PREFIX_SUB_STEP_POSITIVE)Image pulled"; \
 	else \
 		echo "$(PREFIX_SUB_STEP_NEGATIVE)Error pulling image"; \
@@ -404,9 +404,9 @@ rm: _prerequisites _require-docker-container-not-status-paused
 	fi
 
 rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
-	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
+	@ if [[ -n $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) ]]; then \
 		echo "$(PREFIX_STEP)Untagging image"; \
-		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
 		$(docker) rmi \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
 		if [[ $${?} -eq 0 ]]; then \

--- a/Makefile
+++ b/Makefile
@@ -172,76 +172,76 @@ endif
 
 _require-docker-container:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-		echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
 		exit 1; \
 	fi
 
 _require-docker-container-not:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
-		echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+		echo "$(PREFIX_SUB_STEP)Try removing it with: make rm"; \
 		exit 1; \
 	fi
 
 _require-docker-container-not-status-paused:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
-		echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+		echo "$(PREFIX_SUB_STEP)Try unpausing it with: make unpause"; \
 		exit 1; \
 	fi
 
 _require-docker-container-status-created:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
-		echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be created."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
 		exit 1; \
 	fi
 
 _require-docker-container-status-exited:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
-		echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+		echo "$(PREFIX_SUB_STEP)Try stopping it with: make stop"; \
 		exit 1; \
 	fi
 
 _require-docker-container-status-paused:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
-		echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+		echo "$(PREFIX_SUB_STEP)Try pausing it with: make pause"; \
 		exit 1; \
 	fi
 
 _require-docker-container-status-running:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
-		echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be running."; \
+		echo "$(PREFIX_SUB_STEP)Try starting it with: make start"; \
 		exit 1; \
 	fi
 
 _require-docker-image-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
 		exit 1; \
 	fi
 
 _require-docker-release-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-		echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_SUB_STEP)A release tag is required for this operation."; \
 		exit 1; \
 	fi
 
 _require-package-path:
 	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
-		echo "$(PREFIX_STEP) Creating package directory"; \
+		echo "$(PREFIX_STEP)Creating package directory"; \
 		mkdir -p $(DIST_PATH); \
 	fi; \
 	if [[ ! $${?} -eq 0 ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
+		echo "$(PREFIX_STEP_NEGATIVE)Failed to make package path: $(DIST_PATH)"; \
 		exit 1; \
 	elif [[ -z $(DIST_PATH) ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
+		echo "$(PREFIX_STEP_NEGATIVE)Undefined DIST_PATH"; \
 		exit 1; \
 	fi
 
@@ -252,25 +252,25 @@ all: _prerequisites | build images install start ps
 
 # build NO_CACHE=[{false,true}]
 build: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
+	@ echo "$(PREFIX_STEP)Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 	@ if [[ $(NO_CACHE) == true ]]; then \
-		echo "$(PREFIX_SUB_STEP) Skipping cache"; \
+		echo "$(PREFIX_SUB_STEP)Skipping cache"; \
 	fi
 	@ $(docker) build \
 		--no-cache=$(NO_CACHE) \
 		-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
 		.; \
 	if [[ $${?} -eq 0 ]]; then \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Build complete"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Build complete"; \
 	else \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) Build error"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Build error"; \
 		exit 1; \
 	fi
 
 clean: _prerequisites | terminate rmi
 
 create: _prerequisites _require-docker-container-not
-	@ echo "$(PREFIX_STEP) Creating container"
+	@ echo "$(PREFIX_STEP)Creating container"
 	@ set -x; \
 	$(docker) create \
 		$(DOCKER_CONTAINER_PARAMETERS) \
@@ -278,10 +278,10 @@ create: _prerequisites _require-docker-container-not
 		$(DOCKER_CONTAINER_OPTS) \
 		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-		echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Container created"; \
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container created"; \
 	else \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container creation failed"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container creation failed"; \
 		exit 1; \
 	fi
 
@@ -290,20 +290,20 @@ dist: _prerequisites _require-docker-release-tag _require-package-path | pull
 		$(DIST_PATH) \
 	))
 	@ if [[ -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-		echo "$(PREFIX_STEP) Saving package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
+		echo "$(PREFIX_STEP)Saving package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Package already exists"; \
 	else \
-		echo "$(PREFIX_STEP) Saving package"; \
+		echo "$(PREFIX_STEP)Saving package"; \
 		$(docker) save \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
 			$(xz) -9 > \
 				$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
 		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
+			echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package saved"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package save error"; \
 			exit 1; \
 		fi; \
 	fi
@@ -313,19 +313,19 @@ distclean: _prerequisites _require-docker-release-tag _require-package-path | cl
 		$(DIST_PATH) \
 	))
 	@ if [[ -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-		echo "$(PREFIX_STEP) Deleting package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		echo "$(PREFIX_STEP)Deleting package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 		find $($@_dist_path) \
 			-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
 			-delete; \
 		if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package cleanup complete"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package cleanup failed"; \
 			exit 1; \
 		fi; \
 	else \
-		echo "$(PREFIX_STEP) Package cleanup skipped"; \
+		echo "$(PREFIX_STEP)Package cleanup skipped"; \
 	fi
 
 exec: _prerequisites
@@ -351,33 +351,33 @@ load: _prerequisites _require-docker-release-tag _require-package-path
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
-	@ echo "$(PREFIX_STEP) Loading image from package"; \
-	echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+	@ echo "$(PREFIX_STEP)Loading image from package"; \
+	echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 	if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-		echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
+		echo "$(PREFIX_STEP_NEGATIVE)Package not found"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
 		exit 1; \
 	else \
 		$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
 			$(docker) load; \
-		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
+		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image loaded"; \
 	fi
 
 pause: _prerequisites _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Pausing container"
+	@ echo "$(PREFIX_STEP)Pausing container"
 	@ $(docker) pause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container paused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container paused"
 
 pull: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Pulling image from registry"
+	@ echo "$(PREFIX_STEP)Pulling image from registry"
 	@ $(docker) pull \
 		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
 	if [[ $${?} -eq 0 ]]; then \
-		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Image pulled"; \
+		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image pulled"; \
 	else \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) Error pulling image"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Error pulling image"; \
 		exit 1; \
 	fi
 
@@ -385,42 +385,42 @@ ps: _prerequisites _require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
 
 restart: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Restarting container"
+	@ echo "$(PREFIX_STEP)Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container restarted"
 
 rm: _prerequisites _require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-		echo "$(PREFIX_STEP) Container removal skipped"; \
+		echo "$(PREFIX_STEP)Container removal skipped"; \
 	else \
-		echo "$(PREFIX_STEP) Removing container"; \
+		echo "$(PREFIX_STEP)Removing container"; \
 		$(docker) rm -f $(DOCKER_NAME); \
 		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container removed"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container removal failed"; \
 			exit 1; \
 		fi; \
 	fi
 
 rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
 	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
-		echo "$(PREFIX_STEP) Untagging image"; \
-		echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_STEP)Untagging image"; \
+		echo "$(PREFIX_SUB_STEP)$$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
 		$(docker) rmi \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
 		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image untagged"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Image untagged"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error untagging image"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error untagging image"; \
 			exit 1; \
 		fi; \
 	else \
-		echo "$(PREFIX_STEP) Untagging image skipped"; \
+		echo "$(PREFIX_STEP)Untagging image skipped"; \
 	fi
 
 run: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Running container"
+	@ echo "$(PREFIX_STEP)Running container"
 	@ set -x; \
 	$(docker) run \
 		--detach \
@@ -429,64 +429,64 @@ run: _prerequisites _require-docker-image-tag
 		$(DOCKER_CONTAINER_OPTS) \
 		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-		echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Container running"; \
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container running"; \
 	else \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container run failed"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container run failed"; \
 		exit 1; \
 	fi
 
 start: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Starting container"
+	@ echo "$(PREFIX_STEP)Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
 		&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 		$(docker) start $(DOCKER_NAME) 1> /dev/null; \
 	fi
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-		echo "$(PREFIX_SUB_STEP_POSITIVE) Container started"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container started"; \
 	else \
-		echo "$(PREFIX_SUB_STEP_NEGATIVE) Container start failed"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container start failed"; \
 		exit 1; \
 	fi
 
 stop: _prerequisites _require-docker-container-not-status-paused _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Stopping container"
+	@ echo "$(PREFIX_STEP)Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 		$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
 		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container stopped"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error stopping container"; \
 			exit 1; \
 		fi; \
 	fi
 
 terminate: _prerequisites
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-		echo "$(PREFIX_STEP) Container termination skipped"; \
+		echo "$(PREFIX_STEP)Container termination skipped"; \
 	else \
-		echo "$(PREFIX_STEP) Terminating container"; \
+		echo "$(PREFIX_STEP)Terminating container"; \
 		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Unpausing container"; \
+			echo "$(PREFIX_SUB_STEP)Unpausing container"; \
 			$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
 		fi; \
 		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Stopping container"; \
+			echo "$(PREFIX_SUB_STEP)Stopping container"; \
 			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
 		fi; \
 		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_SUB_STEP) Removing container"; \
+			echo "$(PREFIX_SUB_STEP)Removing container"; \
 			$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
 		fi; \
 		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container terminated"; \
 		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container termination failed"; \
 			exit 1; \
 		fi; \
 	fi
 
 unpause: _prerequisites _require-docker-container-status-paused
-	@ echo "$(PREFIX_STEP) Unpausing container"
+	@ echo "$(PREFIX_STEP)Unpausing container"
 	@ $(docker) unpause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container unpaused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container unpaused"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ Apache PHP web server, loading only a minimal set of Apache modules by default. 
 
 ## Overview & links
 
-- centos-6 [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/Dockerfile)
-- centos-6-httpd24u-php56u [(centos-6-httpd24u-php56u/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6-httpd24u-php56u/Dockerfile)
+### Tags and respective `Dockerfile` links
+
+- `centos-6-httpd24u-php56u`, `centos-6-httpd24u-php56u-2.0.0`, `2.0.0` [(centos-6-httpd24u-php56u/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6-httpd24u-php56u/Dockerfile)
+- `centos-6`, `centos-6-1.8.0`, `1.8.0` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/Dockerfile)
 
 #### centos-6
 
-The latest CentOS-6 Standard Package based release can be pulled from the `centos-6` Docker tag. For a specific release tag the convention is `centos-6-1.8.0` for the [1.8.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/1.8.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd CentOS package), uses the mpm_prefork_module and php5_module modules for handling [PHP](http://php.net/).
+The latest CentOS-6 Standard Package based release can be pulled from the `centos-6` Docker tag. It is recommended to select a specific release tag - the convention is `centos-6-1.8.0` or `1.8.0` for the [1.8.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/1.8.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd CentOS package), uses the mpm_prefork_module and php5_module modules for handling [PHP](http://php.net/).
 
 #### centos-6-httpd24u-php56u
 
-The latest CentOS-6 [IUS](https://ius.io) Apache 2.4, PHP-FPM 5.6 based release can be pulled from the `centos-6-httpd24u-php56u` Docker tag. For a specific release tag the convention is `centos-6-httpd24u-php56u-2.0.0` for the [2.0.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/2.0.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd24u package), uses the mpm_prefork_module and php-fpm for handling [PHP](http://php.net/). This version has the option of using the worker or event MPM.
+The latest CentOS-6 [IUS](https://ius.io) Apache 2.4, PHP-FPM 5.6 based release can be pulled from the `centos-6-httpd24u-php56u` Docker tag. It is recommended to select a specific release tag - the convention is `centos-6-httpd24u-php56u-2.0.0` or `2.0.0` for the [2.0.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/2.0.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd24u package), uses the mpm_prefork_module and php-fpm for handling [PHP](http://php.net/). This version has the option of using the worker or event MPM.
 
 Included in the build are the [SCL](https://www.softwarecollections.org/), [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), [elinks](http://elinks.or.cz) (for fullstatus support), PHP [Memcached](http://pecl.php.net/package/memcached) are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout). The `centos-6` "Standard" PHP 5.3 build includes PHP [APC](http://pecl.php.net/package/APC) where Zend Opcache is bundled in  PHP 5.6.
 

--- a/environment.mk
+++ b/environment.mk
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------------------------
 DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-apache-php
+SHPEC_ROOT := test/shpec
 
 # Tag validation patterns
 DOCKER_IMAGE_TAG_PATTERN := ^(latest|centos-[6-7]|centos-6-httpd24u-php56u|(([1-3]|centos-(6-1|6-httpd24u-php56u-2|7-3))\.[0-9]+\.[0-9]+))$

--- a/environment.mk
+++ b/environment.mk
@@ -5,8 +5,8 @@ DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$
-DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$
+DOCKER_IMAGE_TAG_PATTERN := ^(latest|centos-[6-7]|centos-6-httpd24u-php56u|(([1-3]|centos-(6-1|6-httpd24u-php56u-2|7-3))\.[0-9]+\.[0-9]+))$
+DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^(1|2|centos-(6-1|6-httpd24u-php56u-2))\.[0-9]+\.[0-9]+$
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -5,8 +5,8 @@ DOCKER_USER=jdeathe
 DOCKER_IMAGE_NAME=centos-ssh-apache-php
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$'
-DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$'
+DOCKER_IMAGE_TAG_PATTERN='^(latest|centos-[6-7]|centos-6-httpd24u-php56u|(([1-3]|centos-(6-1|6-httpd24u-php56u-2|7-3))\.[0-9]+\.[0-9]+))$'
+DOCKER_IMAGE_RELEASE_TAG_PATTERN='^(1|2|centos-(6-1|6-httpd24u-php56u-2))\.[0-9]+\.[0-9]+$'
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/test/shpec/makefile.sh
+++ b/test/shpec/makefile.sh
@@ -1,0 +1,114 @@
+describe "Makefile"
+	readonly DOCKER_NAME="makefile_test"
+
+	it "builds the image"
+		local status_make_build
+
+		make build &> /dev/null
+		status_make_build=${?}
+
+		assert equal ${status_make_build} 0
+	end
+
+	it "creates the container"
+		local status_make_install
+
+		make install &> /dev/null
+		status_make_install=${?}
+
+		assert equal ${status_make_install} 0
+	end
+
+	it "starts the container"
+		local status_make_start
+
+		make start &> /dev/null
+		status_make_start=${?}
+
+		assert equal ${status_make_start} 0
+	end
+
+	it "pauses the container"
+		local status_make_pause
+
+		make pause &> /dev/null
+		status_make_pause=${?}
+
+		assert equal ${status_make_pause} 0
+	end
+
+	it "unpauses the container"
+		local status_make_unpause
+
+		make unpause &> /dev/null
+		status_make_unpause=${?}
+
+		assert equal ${status_make_unpause} 0
+	end
+
+	it "restarts the container"
+		local status_make_restart
+
+		make restart &> /dev/null
+		status_make_restart=${?}
+
+		assert equal ${status_make_restart} 0
+	end
+
+	it "outputs the container logs"
+		local status_make_logs
+		local content_make_logs
+
+		content_make_logs=$(
+			make logs
+		)
+		status_make_logs=${?}
+
+		assert equal ${status_make_logs} 0
+	end
+
+	it "terminates the container"
+		local status_make_terminate
+
+		make terminate &> /dev/null
+		status_make_terminate=${?}
+
+		assert equal ${status_make_terminate} 0
+	end
+
+	it "runs the container"
+		local status_make_run
+
+		make run &> /dev/null
+		status_make_run=${?}
+
+		assert equal ${status_make_run} 0
+	end
+
+	it "stops the container"
+		local status_make_stop
+
+		make stop &> /dev/null
+		status_make_stop=${?}
+
+		assert equal ${status_make_stop} 0
+	end
+
+	it "deletes the container"
+		local status_make_rm
+	
+		make rm &> /dev/null
+		status_make_rm=${?}
+	
+		assert equal ${status_make_rm} 0
+	end
+
+	it "untags the image"
+		local status_make_clean
+	
+		make rmi &> /dev/null
+		status_make_clean=${?}
+	
+		assert equal ${status_make_clean} 0
+	end
+end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -958,6 +958,70 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			# assert equal "${apache_run_group}" "agrp"
 		end
 
+		it "Allows configuration of the ServerName."
+			local curl_response_code_default=""
+			local curl_response_code_server_named=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_SERVER_NAME="test.local" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			# Add a default VirtualHost that rejects access (403 response).
+			docker exec -i \
+				apache-php.pool-1.1.1 \
+				tee /etc/services-config/httpd/conf.d/05-vhost.conf 1> /dev/null <<-CONFIG
+			Listen 8443
+			<IfVersion < 2.4>
+			    NameVirtualHost *:80
+			    NameVirtualHost *:8443
+			</IfVersion>
+
+			<VirtualHost *:80 *:8443>
+			    ServerName localhost.localdomain
+			    DocumentRoot /var/www/html
+
+			    <Directory /var/www/html>
+			        ErrorDocument 403 "403 Forbidden"
+			        <IfVersion < 2.4>
+			            Order deny,allow
+			            Deny from all
+			        </IfVersion>
+			        <IfVersion >= 2.4>
+			            Require all denied
+			        </IfVersion>
+			    </Directory>
+			</VirtualHost>
+			CONFIG
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c 'apachectl graceful'
+
+			curl_response_code_default="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			curl_response_code_server_named="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					--header 'Host: test.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
+		end
+
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
 		trap - \
 			INT TERM EXIT

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,0 +1,98 @@
+readonly BOOTSTRAP_BACKOFF_TIME=3
+readonly DOCKER_HOSTNAME="localhost"
+readonly TEST_DIRECTORY="test"
+
+# These should ideally be a static value but hosts might be using this port so 
+# need to allow for alternatives.
+DOCKER_PORT_MAP_TCP_22="${DOCKER_PORT_MAP_TCP_22:-NULL}"
+DOCKER_PORT_MAP_TCP_80="${DOCKER_PORT_MAP_TCP_80:-8080}"
+DOCKER_PORT_MAP_TCP_443="${DOCKER_PORT_MAP_TCP_443:-9443}"
+DOCKER_PORT_MAP_TCP_8443="${DOCKER_PORT_MAP_TCP_8443:-NULL}"
+
+function docker_terminate_container ()
+{
+	local CONTAINER="${1}"
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" \
+		--filter "status=paused" &> /dev/null; then
+		docker unpause ${CONTAINER} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" \
+		--filter "status=running" &> /dev/null; then
+		docker stop ${CONTAINER} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" &> /dev/null; then
+		docker rm -vf ${CONTAINER} &> /dev/null
+	fi
+}
+
+function test_setup ()
+{
+	return 0
+}
+
+if [[ ! -d ${TEST_DIRECTORY} ]]; then
+	printf -- \
+		"ERROR: Please run from the project root.\n" \
+		>&2
+	exit 1
+fi
+
+describe "jdeathe/centos-ssh-apache-php:latest"
+	test_setup
+
+	describe "Basic Apache PHP operations"
+		trap "docker_terminate_container apache-php.pool-1.1.1 &> /dev/null" \
+			INT TERM EXIT
+
+		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+		it "Runs an Apache PHP container named apache-php.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_80}."
+			local container_port_80=""
+			local header_server=""
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				jdeathe/centos-ssh-apache-php:latest &> /dev/null
+
+			container_port_80="$(
+				docker port \
+				apache-php.pool-1.1.1 \
+				80/tcp
+			)"
+			container_port_80=${container_port_80##*:}
+
+			if [[ ${DOCKER_PORT_MAP_TCP_80} == 0 ]] \
+				|| [[ -z ${DOCKER_PORT_MAP_TCP_80} ]]; then
+				assert gt "${container_port_80}" "30000"
+			else
+				assert equal "${container_port_80}" "${DOCKER_PORT_MAP_TCP_80}"
+			fi
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			it "Retuns a Server header of 'Apache' only."
+				header_server="$(
+					curl -sI \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80} \
+					| grep '^Server: ' \
+					| cut -c 9- \
+					| tr -d '\r'
+				)"
+
+				assert equal "${header_server}" "Apache"
+			end
+		end
+
+		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+		trap - \
+			INT TERM EXIT
+	end
+end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -986,6 +986,28 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_header_x_service_uid}" 0
 		end
 
+		it "Allows configuration of the system user."
+			local apache_system_user=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_SYSTEM_USER="app-user" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_system_user="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					stat -c '%U' /var/www/app/public_html
+			)"
+
+			assert equal "${apache_system_user}" "app-user"
+		end
+
 		it "Allows configuration of the user used to run Apache."
 			local apache_run_user=""
 
@@ -993,7 +1015,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
-				--env APACHE_RUN_USER="ausr" \
+				--env APACHE_RUN_USER="runner" \
 				jdeathe/centos-ssh-apache-php:latest \
 			&> /dev/null
 
@@ -1009,7 +1031,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			)"
 
 			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_user}" "ausr"
+			# assert equal "${apache_run_user}" "runner"
 		end
 
 		it "Allows configuration of the group used to run Apache."
@@ -1019,7 +1041,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
-				--env APACHE_RUN_GROUP="agrp" \
+				--env APACHE_RUN_GROUP="runners" \
 				jdeathe/centos-ssh-apache-php:latest \
 			&> /dev/null
 
@@ -1035,7 +1057,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			)"
 
 			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_group}" "agrp"
+			# assert equal "${apache_run_group}" "runners"
 		end
 
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -968,6 +968,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				--name apache-php.pool-1.1.1 \
 				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 				--env APACHE_SERVER_NAME="test.local" \
+				--env APACHE_SERVER_ALIAS="www.test.local" \
 				jdeathe/centos-ssh-apache-php:latest \
 			&> /dev/null
 
@@ -1020,6 +1021,20 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			)"
 
 			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
+
+			it "Allows configuration of a ServerAlias."
+				local curl_response_code_server_alias=""
+
+				curl_response_code_server_alias="$(
+					curl -s \
+						-o /dev/null \
+						-w "%{http_code}" \
+						--header 'Host: www.test.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				assert equal "${curl_response_code_server_alias}" "200"
+			end
 		end
 
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -50,7 +50,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 		trap "docker_terminate_container apache-php.pool-1.1.1 &> /dev/null" \
 			INT TERM EXIT
 
-		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
 
 		it "Runs an Apache PHP container named apache-php.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_80}."
 			local container_hostname=""
@@ -79,9 +81,13 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			if [[ ${DOCKER_PORT_MAP_TCP_80} == 0 ]] \
 				|| [[ -z ${DOCKER_PORT_MAP_TCP_80} ]]; then
-				assert gt "${container_port_80}" "30000"
+				assert gt \
+					"${container_port_80}" \
+					"30000"
 			else
-				assert equal "${container_port_80}" "${DOCKER_PORT_MAP_TCP_80}"
+				assert equal \
+					"${container_port_80}" \
+					"${DOCKER_PORT_MAP_TCP_80}"
 			fi
 
 			sleep ${BOOTSTRAP_BACKOFF_TIME}
@@ -96,7 +102,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					| tr -d '\r'
 				)"
 
-				assert equal "${header_server}" "Apache"
+				assert equal \
+					"${header_server}" \
+					"Apache"
 			end
 
 			it "Responds with a X-Service-UID header of the container hostname."
@@ -109,7 +117,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					| tr -d '\r'
 				)"
 
-				assert equal "${header_x_service_uid}" "${container_hostname}"
+				assert equal \
+					"${header_x_service_uid}" \
+					"${container_hostname}"
 			end
 
 			it "Outputs Apache Details in the docker logs."
@@ -122,7 +132,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					| tr -d '\r'
 				)"
 
-				assert equal "${apache_details_title}" "Apache Details"
+				assert equal \
+					"${apache_details_title}" \
+					"Apache Details"
 
 				it "Includes the system user default (app)."
 					local apache_system_user=""
@@ -135,7 +147,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_system_user}" "app"
+					assert equal \
+						"${apache_system_user}" \
+						"app"
 				end
 
 				it "Includes the run user default (app-www)."
@@ -149,7 +163,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_run_user}" "app-www"
+					assert equal \
+						"${apache_run_user}" \
+						"app-www"
 				end
 
 				it "Includes the run group default (app-www)."
@@ -163,7 +179,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_run_group}" "app-www"
+					assert equal \
+						"${apache_run_group}" \
+						"app-www"
 				end
 
 				it "Includes the server name default (app-1.local)."
@@ -177,7 +195,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_server_name}" "app-1.local"
+					assert equal \
+						"${apache_server_name}" \
+						"app-1.local"
 				end
 
 				it "Includes the server alias default (EMPTY)."
@@ -191,7 +211,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_server_alias}" ""
+					assert equal \
+						"${apache_server_alias}" \
+						""
 				end
 
 				it "Includes the header X-Service-UID default ({{HOSTNAME}} replacement)."
@@ -205,7 +227,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_header_x_service_uid}" "${container_hostname}"
+					assert equal \
+						"${apache_header_x_service_uid}" \
+						"${container_hostname}"
 				end
 
 				it "Includes the default document root APACHE_CONTENT_ROOT/APACHE_PUBLIC_DIRECTORY (/var/www/app/public_html)."
@@ -220,7 +244,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| awk '{ print $1 }'
 					)"
 
-					assert equal "${apache_document_root}" "/var/www/app/public_html"
+					assert equal \
+						"${apache_document_root}" \
+						"/var/www/app/public_html"
 				end
 
 				# TODO This is included in the logs but not included in the Apache Details.
@@ -236,7 +262,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						| tr -d '\r'
 					)"
 
-					assert equal "${apache_server_mpm}" "prefork"
+					assert equal \
+						"${apache_server_mpm}" \
+						"prefork"
 				end
 
 				it "Includes the default modules enabled."
@@ -267,7 +295,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 							| awk '/^ - /'
 					)"
 
-					assert equal "${apache_load_modules}" "${apache_load_modules_details}"
+					assert equal \
+						"${apache_load_modules}" \
+						"${apache_load_modules_details}"
 				end
 			end
 
@@ -290,7 +320,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						'"GET / HTTP/1\.1" 200' \
 				)"
 
-				assert equal "${apache_access_log_entry}" "\"GET / HTTP/1.1\" 200"
+				assert equal \
+					"${apache_access_log_entry}" \
+					"\"GET / HTTP/1.1\" 200"
 
 				it "Logs using the default LogFormat (combined)."
 					local status_apache_access_log_pattern=""
@@ -305,7 +337,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 					status_apache_access_log_pattern=${?}
 
-					assert equal "${status_apache_access_log_pattern}" 0
+					assert equal \
+						"${status_apache_access_log_pattern}" \
+						0
 				end
 			end
 
@@ -327,7 +361,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 				status_apache_error_log_path=${?}
 
-				assert equal "${status_apache_error_log_path}" 0
+				assert equal \
+					"${status_apache_error_log_path}" \
+					0
 			end
 
 			it "Apache server-status can be accessed from localhost."
@@ -343,7 +379,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 				status_apache_server_status_pattern=${?}
 
-				assert equal "${status_apache_server_status_pattern}" 0
+				assert equal \
+					"${status_apache_server_status_pattern}" \
+					0
 
 				it "Excludes information available with ExtendedStatus enabled."
 					local status_apache_server_status_pattern=""
@@ -375,7 +413,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 					status_apache_server_status_pattern=${?}
 
-					assert equal "${status_apache_server_status_pattern}" 1
+					assert equal \
+						"${status_apache_server_status_pattern}" \
+						1
 
 					it "Responds with a 403 status code."
 						local curl_response_code=""
@@ -388,7 +428,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 								http://127.0.0.1:${container_port_80}/server-status\?auto
 						)"
 
-						assert equal "${curl_response_code}" "403"
+						assert equal \
+							"${curl_response_code}" \
+							"403"
 					end
 				end
 			end
@@ -408,7 +450,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					))
 				done
 
-				assert equal "${status_apache_modules_loaded}" 0
+				assert equal \
+					"${status_apache_modules_loaded}" \
+					0
 
 				it "Loads only the required Apache modules."
 					local all_required_apache_modules="${required_apache_modules} ${other_required_apache_modules}"
@@ -428,7 +472,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						fi
 					done
 
-					assert unequal "${status_minimal_apache_modules_loaded}" 1
+					assert unequal \
+						"${status_minimal_apache_modules_loaded}" \
+						1
 				end
 			end
 
@@ -444,11 +490,15 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					| awk '{ print $1":"$2 }'
 				)"
 
-				assert equal "${apache_run_user_group}" "app-www:app-www"
+				assert equal \
+					"${apache_run_user_group}" \
+					"app-www:app-www"
 			end
 		end
 
-		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
 		trap - \
 			INT TERM EXIT
 	end
@@ -461,7 +511,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			local curl_get_request=""
 			local status_apache_access_log_pattern=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -488,14 +540,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_access_log_pattern=${?}
 
-			assert equal "${status_apache_access_log_pattern}" 0
+			assert equal \
+				"${status_apache_access_log_pattern}" \
+				0
 		end
 
 		it "Allows configuration of an alternative, relative, access log path."
 			local apache_access_log_entry=""
 			local curl_get_request=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -521,14 +577,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					'"GET / HTTP/1\.1" 200' \
 			)"
 
-			assert equal "${apache_access_log_entry}" "\"GET / HTTP/1.1\" 200"
+			assert equal \
+				"${apache_access_log_entry}" \
+				"\"GET / HTTP/1.1\" 200"
 		end
 
 		it "Allows configuration of an alternative, absolute, access log path."
 			local apache_access_log_entry=""
 			local curl_get_request=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -554,14 +614,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					'"GET / HTTP/1\.1" 200' \
 			)"
 
-			assert equal "${apache_access_log_entry}" "\"GET / HTTP/1.1\" 200"
+			assert equal \
+				"${apache_access_log_entry}" \
+				"\"GET / HTTP/1.1\" 200"
 		end
 
 		it "Allows configuration of an alternative, relative, error log path."
 			local curl_get_request=""
 			local status_apache_error_log_path=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -586,14 +650,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_error_log_path=${?}
 
-			assert equal "${status_apache_error_log_path}" 0
+			assert equal \
+				"${status_apache_error_log_path}" \
+				0
 		end
 
 		it "Allows configuration of an alternative, absolute, error log path."
 			local curl_get_request=""
 			local status_apache_error_log_path=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -618,14 +686,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_error_log_path=${?}
 
-			assert equal "${status_apache_error_log_path}" 0
+			assert equal \
+				"${status_apache_error_log_path}" \
+				0
 		end
 
-		it "Allows configuration with an alternative log level (e.g debug)."
+		it "Allows configuration of an alternative log level (e.g debug)."
 			local curl_get_request=""
 			local status_apache_error_log_pattern=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -652,13 +724,17 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_error_log_pattern=${?}
 
-			assert equal "${status_apache_error_log_pattern}" 0
+			assert equal \
+				"${status_apache_error_log_pattern}" \
+				0
 		end
 
 		it "Allows extended server-status to be enabled and accessed from localhost."
 			local status_apache_server_status_pattern=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -679,7 +755,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_server_status_pattern=${?}
 
-			assert equal "${status_apache_server_status_pattern}" 0
+			assert equal \
+				"${status_apache_server_status_pattern}" \
+				0
 
 			it "Prevents remote access to server-status."
 				local status_apache_server_status_pattern=""
@@ -694,7 +772,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 				status_apache_server_status_pattern=${?}
 
-				assert equal "${status_apache_server_status_pattern}" 1
+				assert equal \
+					"${status_apache_server_status_pattern}" \
+					1
 
 				it "Responds with a 403 status code."
 					local curl_response_code=""
@@ -707,7 +787,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 							http://127.0.0.1:${container_port_80}/server-status\?auto
 					)"
 
-					assert equal "${curl_response_code}" "403"
+					assert equal \
+						"${curl_response_code}" \
+						"403"
 				end
 			end
 		end
@@ -715,7 +797,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 		it "Allows configuration of the X-Service-UID header."
 			local header_x_service_uid=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -735,12 +819,16 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				| tr -d '\r'
 			)"
 
-			assert equal "${header_x_service_uid}" "host-name@1.2"
+			assert equal \
+				"${header_x_service_uid}" \
+				"host-name@1.2"
 
 			it "Allows the {{HOSTNAME}} placeholder to be included in the value."
 				local header_x_service_uid=""
 
-				docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
 
 				docker run -d \
 					--name apache-php.pool-1.1.1 \
@@ -761,14 +849,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					| tr -d '\r'
 				)"
 
-				assert equal "${header_x_service_uid}" "app-1.local:${DOCKER_PORT_MAP_TCP_80}"
+				assert equal \
+					"${header_x_service_uid}" \
+					"app-1.local:${DOCKER_PORT_MAP_TCP_80}"
 			end
 		end
 
 		it "Allows for loading of additional modules (e.g. rewrite_module)."
 			local status_apache_module_loaded=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -784,13 +876,17 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_module_loaded=${?}
 
-			assert equal "${status_apache_module_loaded}" 0
+			assert equal \
+				"${status_apache_module_loaded}" \
+				0
 		end
 
 		it "Allows configuration of an alternative MPM (e.g. event)."
 			local status_apache_mpm_changed=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -807,13 +903,17 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_apache_mpm_changed=${?}
 
-			assert equal "${status_apache_mpm_changed}" 0
+			assert equal \
+				"${status_apache_mpm_changed}" \
+				0
 		end
 
 		it "Allows configuration of the operating mode internal variable (i.e -D development)."
 			local header_x_service_operating_mode=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -834,13 +934,17 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				| tr -d '\r'
 			)"
 
-			assert equal "${header_x_service_operating_mode}" "development"
+			assert equal \
+				"${header_x_service_operating_mode}" \
+				"development"
 		end
 
 		it "Allows configuration of the system user (i.e. application owner)."
 			local apache_system_user=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -856,13 +960,17 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					stat -c '%U' /var/www/app/public_html
 			)"
 
-			assert equal "${apache_system_user}" "app-user"
+			assert equal \
+				"${apache_system_user}" \
+				"app-user"
 		end
 
 		it "Allows configuration of the run user (i.e. process runner user)."
 			local apache_run_user=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -888,7 +996,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 		it "Allows configuration of the run group (i.e. process runner's group)."
 			local apache_run_group=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -915,7 +1025,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			local curl_response_code_default=""
 			local curl_response_code_server_named=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -973,7 +1085,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					http://127.0.0.1:${container_port_80}
 			)"
 
-			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
+			assert equal \
+				"${curl_response_code_default}:${curl_response_code_server_named}" \
+				"403:200"
 
 			it "Allows configuration of a ServerAlias (e.g www.app-1.local)."
 				local curl_response_code_server_alias=""
@@ -986,14 +1100,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						http://127.0.0.1:${container_port_80}
 				)"
 
-				assert equal "${curl_response_code_server_alias}" "200"
+				assert equal \
+					"${curl_response_code_server_alias}" \
+					"200"
 			end
 		end
 
 		it "Allows configuration of the public directory (e.g web)."
 			local status_header_x_service_uid=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -1023,14 +1141,18 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			status_header_x_service_uid=${?}
 
-			assert equal "${status_header_x_service_uid}" 0
+			assert equal \
+				"${status_header_x_service_uid}" \
+				0
 		end
 
 		it "Allows ssl_module to be enabled to accept encrypted requests (i.e https)."
 			local container_port_443=""
 			local curl_response_code=""
 
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
@@ -1057,7 +1179,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					https://127.0.0.1:${container_port_443}
 			)"
 
-			assert equal "${curl_response_code}" "200"
+			assert equal \
+				"${curl_response_code}" \
+				"200"
 
 			it "Allows configuration of a certificate instead of auto-generating one on startup."
 				local container_port_443=""
@@ -1065,7 +1189,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				local certificate_fingerprint_file=""
 				local certificate_fingerprint_server=""
 
-				docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
 
 				openssl req \
 					-x509 \
@@ -1141,7 +1267,10 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			end
 		end
 
-		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
+
 		trap - \
 			INT TERM EXIT
 	end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -267,8 +267,62 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 					)"
 
 					assert equal "${apache_load_modules}" "${apache_load_modules_details}"
-
 				end
+			end
+
+			it "Logs to the default Apache access log path (/var/www/app/var/log/apache_access_log)."
+				local apache_access_log_entry=""
+				local curl_request_head=""
+
+				curl_get_request="$(
+					curl -s \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				apache_access_log_entry="$(
+					docker exec \
+						apache-php.pool-1.1.1 \
+						tail -n 1 \
+						/var/www/app/var/log/apache_access_log
+				)"
+
+				assert match "${apache_access_log_entry}" ""GET / HTTP/1.1" 200"
+
+				it "Logs using the default LogFormat (combined)."
+					local status_apache_access_log_pattern=""
+
+					docker exec \
+						apache-php.pool-1.1.1 \
+						tail -n 1 \
+						/var/www/app/var/log/apache_access_log \
+					| grep -qE \
+						'^.+ .+ .+ \[.+\] "GET / HTTP/1\.1" 200 .+ ".+" ".*"$'
+
+					status_apache_access_log_pattern=${?}
+
+					assert equal "${status_apache_access_log_pattern}" 0
+				end
+			end
+
+			it "Logs to the default Apache error log path (/var/www/app/var/log/apache_error_log)."
+				local apache_error_log_entry=""
+				local curl_request_head=""
+
+				curl_get_request="$(
+					curl -s \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				apache_error_log_entry="$(
+					docker exec \
+						apache-php.pool-1.1.1 \
+						tail -n 1 \
+						/var/www/app/var/log/apache_error_log
+				)"
+
+				assert equal "${apache_error_log_entry}" ""
 			end
 		end
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -85,7 +85,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			sleep ${BOOTSTRAP_BACKOFF_TIME}
 
-			it "Retuns a Server header of 'Apache' only."
+			it "Responds with a Server header of 'Apache' only."
 				header_server="$(
 					curl -sI \
 						--header 'Host: app-1.local' \
@@ -98,7 +98,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				assert equal "${header_server}" "Apache"
 			end
 
-			it "Retuns a X-Service-UID header with the value of the container hostname."
+			it "Responds with a X-Service-UID header of the container hostname."
 				header_x_service_uid="$(
 					curl -sI \
 						--header 'Host: app-1.local' \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -787,7 +787,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_module_loaded}" 0
 		end
 
-		it "Allows mod_ssl to be enabled."
+		it "Allows ssl_module to be enabled to accept encrypted requests (https)."
 			local container_port_443=""
 			local curl_response_code=""
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -271,7 +271,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				end
 			end
 
-			it "Logs to the default Apache access log path (/var/www/app/var/log/apache_access_log)."
+			it "Logs to the default access log path (/var/www/app/var/log/apache_access_log)."
 				local apache_access_log_entry=""
 				local curl_get_request=""
 
@@ -309,7 +309,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				end
 			end
 
-			it "Logs to the default Apache error log path (/var/www/app/var/log/apache_error_log)."
+			it "Logs to the default error log path (/var/www/app/var/log/apache_error_log)."
 				local status_apache_error_log_path=""
 				local curl_get_request=""
 
@@ -432,7 +432,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				end
 			end
 
-			it "Runs Apache using the default user:group (app-www:app-www)."
+			it "Runs the using the default user:group (app-www:app-www)."
 				local apache_run_user_group=""
 
 				apache_run_user_group="$(
@@ -457,7 +457,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 		trap "docker_terminate_container apache-php.pool-1.1.1 &> /dev/null" \
 			INT TERM EXIT
 
-		it "Allows configuration with Apache common LogFormat."
+		it "Allows configuration of access logs written in common LogFormat."
 			local curl_get_request=""
 			local status_apache_access_log_pattern=""
 
@@ -491,7 +491,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_access_log_pattern}" 0
 		end
 
-		it "Allows configuration with an alternative, relative, access log path."
+		it "Allows configuration of an alternative, relative, access log path."
 			local apache_access_log_entry=""
 			local curl_get_request=""
 
@@ -524,7 +524,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${apache_access_log_entry}" "\"GET / HTTP/1.1\" 200"
 		end
 
-		it "Allows configuration with an alternative, absolute, access log path."
+		it "Allows configuration of an alternative, absolute, access log path."
 			local apache_access_log_entry=""
 			local curl_get_request=""
 
@@ -557,7 +557,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${apache_access_log_entry}" "\"GET / HTTP/1.1\" 200"
 		end
 
-		it "Allows configuration with an alternative, relative, error log path."
+		it "Allows configuration of an alternative, relative, error log path."
 			local curl_get_request=""
 			local status_apache_error_log_path=""
 
@@ -589,7 +589,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_error_log_path}" 0
 		end
 
-		it "Allows configuration with an alternative, absolute, error log path."
+		it "Allows configuration of an alternative, absolute, error log path."
 			local curl_get_request=""
 			local status_apache_error_log_path=""
 
@@ -621,7 +621,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_error_log_path}" 0
 		end
 
-		it "Allows configuration with an alternative log level."
+		it "Allows configuration with an alternative log level (e.g debug)."
 			local curl_get_request=""
 			local status_apache_error_log_pattern=""
 
@@ -712,7 +712,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			end
 		end
 
-		it "Allows the header X-Service-UID to be set to a string value."
+		it "Allows configuration of the X-Service-UID header."
 			local header_x_service_uid=""
 
 			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
@@ -765,7 +765,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			end
 		end
 
-		it "Allows loading of additional Apache modules (e.g. rewrite_module)."
+		it "Allows for loading of additional modules (e.g. rewrite_module)."
 			local status_apache_module_loaded=""
 
 			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
@@ -787,7 +787,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_module_loaded}" 0
 		end
 
-		it "Allows ssl_module to be enabled to accept encrypted requests (https)."
+		it "Allows ssl_module to be enabled to accept encrypted requests (i.e https)."
 			local container_port_443=""
 			local curl_response_code=""
 
@@ -821,7 +821,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${curl_response_code}" "200"
 		end
 
-		it "Allows configuration of an alternative Apache MPM (event)."
+		it "Allows configuration of an alternative MPM (e.g. event)."
 			local status_apache_mpm_changed=""
 
 			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
@@ -844,7 +844,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${status_apache_mpm_changed}" 0
 		end
 
-		it "Allows configuration of the Apache internal variable for operating mode."
+		it "Allows configuration of the operating mode internal variable (i.e -D development)."
 			local header_x_service_operating_mode=""
 
 			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
@@ -871,7 +871,81 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${header_x_service_operating_mode}" "development"
 		end
 
-		it "Allows configuration of the ServerName."
+		it "Allows configuration of the system user (i.e. application owner)."
+			local apache_system_user=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_SYSTEM_USER="app-user" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_system_user="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					stat -c '%U' /var/www/app/public_html
+			)"
+
+			assert equal "${apache_system_user}" "app-user"
+		end
+
+		it "Allows configuration of the run user (i.e. process runner user)."
+			local apache_run_user=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_RUN_USER="runner" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_run_user="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					ps axo user,group,comm \
+				| grep httpd \
+				| tail -n 1 \
+				| awk '{ print $1 }'
+			)"
+
+			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
+			# assert equal "${apache_run_user}" "runner"
+		end
+
+		it "Allows configuration of the run group (i.e. process runner's group)."
+			local apache_run_group=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_RUN_GROUP="runners" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_run_group="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					ps axo user,group,comm \
+				| grep httpd \
+				| tail -n 1 \
+				| awk '{ print $2 }'
+			)"
+
+			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
+			# assert equal "${apache_run_group}" "runners"
+		end
+
+		it "Allows configuration of the ServerName (e.g test.local)."
 			local curl_response_code_default=""
 			local curl_response_code_server_named=""
 
@@ -935,7 +1009,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
 
-			it "Allows configuration of a ServerAlias."
+			it "Allows configuration of a ServerAlias (e.g www.test.local)."
 				local curl_response_code_server_alias=""
 
 				curl_response_code_server_alias="$(
@@ -950,7 +1024,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			end
 		end
 
-		it "Allows configuration of the Apache public directory."
+		it "Allows configuration of the public directory (e.g web)."
 			local status_header_x_service_uid=""
 
 			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
@@ -984,80 +1058,6 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			status_header_x_service_uid=${?}
 
 			assert equal "${status_header_x_service_uid}" 0
-		end
-
-		it "Allows configuration of the system user."
-			local apache_system_user=""
-
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
-
-			docker run -d \
-				--name apache-php.pool-1.1.1 \
-				--env APACHE_SYSTEM_USER="app-user" \
-				jdeathe/centos-ssh-apache-php:latest \
-			&> /dev/null
-
-			sleep ${BOOTSTRAP_BACKOFF_TIME}
-
-			apache_system_user="$(
-				docker exec \
-					apache-php.pool-1.1.1 \
-					stat -c '%U' /var/www/app/public_html
-			)"
-
-			assert equal "${apache_system_user}" "app-user"
-		end
-
-		it "Allows configuration of the user used to run Apache."
-			local apache_run_user=""
-
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
-
-			docker run -d \
-				--name apache-php.pool-1.1.1 \
-				--env APACHE_RUN_USER="runner" \
-				jdeathe/centos-ssh-apache-php:latest \
-			&> /dev/null
-
-			sleep ${BOOTSTRAP_BACKOFF_TIME}
-
-			apache_run_user="$(
-				docker exec \
-					apache-php.pool-1.1.1 \
-					ps axo user,group,comm \
-				| grep httpd \
-				| tail -n 1 \
-				| awk '{ print $1 }'
-			)"
-
-			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_user}" "runner"
-		end
-
-		it "Allows configuration of the group used to run Apache."
-			local apache_run_group=""
-
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
-
-			docker run -d \
-				--name apache-php.pool-1.1.1 \
-				--env APACHE_RUN_GROUP="runners" \
-				jdeathe/centos-ssh-apache-php:latest \
-			&> /dev/null
-
-			sleep ${BOOTSTRAP_BACKOFF_TIME}
-
-			apache_run_group="$(
-				docker exec \
-					apache-php.pool-1.1.1 \
-					ps axo user,group,comm \
-				| grep httpd \
-				| tail -n 1 \
-				| awk '{ print $2 }'
-			)"
-
-			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_group}" "runners"
 		end
 
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1433,6 +1433,37 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			end
 		end
 
+		it "Allows configuration of the PHP date.timezone (e.g Europe/London)."
+			local php_date_timezone=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env PHP_OPTIONS_DATE_TIMEZONE="Europe/London" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			php_date_timezone="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					php \
+						-r \
+						"printf('%s', ini_get('date.timezone'));"
+			)"
+
+			status_apache_server_status_pattern=${?}
+
+			assert equal \
+				"${php_date_timezone}" \
+				"Europe/London"
+		end
+
 		docker_terminate_container \
 			apache-php.pool-1.1.1 \
 		&> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -929,7 +929,8 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				| awk '{ print $1 }'
 			)"
 
-			assert equal "${apache_run_user}" "ausr"
+			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
+			# assert equal "${apache_run_user}" "ausr"
 		end
 
 		it "Allows configuration of the group used to run Apache."

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -871,6 +871,85 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${header_x_service_operating_mode}" "development"
 		end
 
+		it "Allows configuration of the ServerName."
+			local curl_response_code_default=""
+			local curl_response_code_server_named=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_SERVER_NAME="test.local" \
+				--env APACHE_SERVER_ALIAS="www.test.local" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			# Add a default VirtualHost that rejects access (403 response).
+			docker exec -i \
+				apache-php.pool-1.1.1 \
+				tee /etc/services-config/httpd/conf.d/05-vhost.conf 1> /dev/null <<-CONFIG
+			Listen 8443
+			<IfVersion < 2.4>
+			    NameVirtualHost *:80
+			    NameVirtualHost *:8443
+			</IfVersion>
+
+			<VirtualHost *:80 *:8443>
+			    ServerName localhost.localdomain
+			    DocumentRoot /var/www/html
+
+			    <Directory /var/www/html>
+			        ErrorDocument 403 "403 Forbidden"
+			        <IfVersion < 2.4>
+			            Order deny,allow
+			            Deny from all
+			        </IfVersion>
+			        <IfVersion >= 2.4>
+			            Require all denied
+			        </IfVersion>
+			    </Directory>
+			</VirtualHost>
+			CONFIG
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c 'apachectl graceful'
+
+			curl_response_code_default="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			curl_response_code_server_named="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					--header 'Host: test.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
+
+			it "Allows configuration of a ServerAlias."
+				local curl_response_code_server_alias=""
+
+				curl_response_code_server_alias="$(
+					curl -s \
+						-o /dev/null \
+						-w "%{http_code}" \
+						--header 'Host: www.test.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				assert equal "${curl_response_code_server_alias}" "200"
+			end
+		end
+
 		it "Allows configuration of the Apache public directory."
 			local status_header_x_service_uid=""
 
@@ -957,85 +1036,6 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
 			# assert equal "${apache_run_group}" "agrp"
-		end
-
-		it "Allows configuration of the ServerName."
-			local curl_response_code_default=""
-			local curl_response_code_server_named=""
-
-			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
-
-			docker run -d \
-				--name apache-php.pool-1.1.1 \
-				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
-				--env APACHE_SERVER_NAME="test.local" \
-				--env APACHE_SERVER_ALIAS="www.test.local" \
-				jdeathe/centos-ssh-apache-php:latest \
-			&> /dev/null
-
-			# Add a default VirtualHost that rejects access (403 response).
-			docker exec -i \
-				apache-php.pool-1.1.1 \
-				tee /etc/services-config/httpd/conf.d/05-vhost.conf 1> /dev/null <<-CONFIG
-			Listen 8443
-			<IfVersion < 2.4>
-			    NameVirtualHost *:80
-			    NameVirtualHost *:8443
-			</IfVersion>
-
-			<VirtualHost *:80 *:8443>
-			    ServerName localhost.localdomain
-			    DocumentRoot /var/www/html
-
-			    <Directory /var/www/html>
-			        ErrorDocument 403 "403 Forbidden"
-			        <IfVersion < 2.4>
-			            Order deny,allow
-			            Deny from all
-			        </IfVersion>
-			        <IfVersion >= 2.4>
-			            Require all denied
-			        </IfVersion>
-			    </Directory>
-			</VirtualHost>
-			CONFIG
-
-			sleep ${BOOTSTRAP_BACKOFF_TIME}
-
-			docker exec \
-				apache-php.pool-1.1.1 \
-				bash -c 'apachectl graceful'
-
-			curl_response_code_default="$(
-				curl -s \
-					-o /dev/null \
-					-w "%{http_code}" \
-					http://127.0.0.1:${container_port_80}
-			)"
-
-			curl_response_code_server_named="$(
-				curl -s \
-					-o /dev/null \
-					-w "%{http_code}" \
-					--header 'Host: test.local' \
-					http://127.0.0.1:${container_port_80}
-			)"
-
-			assert equal "${curl_response_code_default}:${curl_response_code_server_named}" "403:200"
-
-			it "Allows configuration of a ServerAlias."
-				local curl_response_code_server_alias=""
-
-				curl_response_code_server_alias="$(
-					curl -s \
-						-o /dev/null \
-						-w "%{http_code}" \
-						--header 'Host: www.test.local' \
-						http://127.0.0.1:${container_port_80}
-				)"
-
-				assert equal "${curl_response_code_server_alias}" "200"
-			end
 		end
 
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -61,7 +61,8 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
 				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
-				jdeathe/centos-ssh-apache-php:latest &> /dev/null
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
 
 			container_hostname="$(
 				docker exec \
@@ -298,7 +299,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 						/var/www/app/var/log/apache_access_log \
 					| grep -qE \
 						'^.+ .+ .+ \[.+\] "GET / HTTP/1\.1" 200 .+ ".+" ".*"$' \
-					| &> /dev/null
+					&> /dev/null
 
 					status_apache_access_log_pattern=${?}
 
@@ -346,7 +347,8 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				--name apache-php.pool-1.1.1 \
 				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 				--env APACHE_CUSTOM_LOG_FORMAT="common" \
-				jdeathe/centos-ssh-apache-php:latest &> /dev/null
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
 
 			sleep ${BOOTSTRAP_BACKOFF_TIME}
 
@@ -362,7 +364,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				/var/www/app/var/log/apache_access_log \
 			| grep -qE \
 				'^.+ .+ .+ \[.+\] "GET / HTTP/1\.1" 200 .+$' \
-			| &> /dev/null
+			&> /dev/null
 
 			status_apache_access_log_pattern=${?}
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -807,6 +807,29 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 			assert equal "${curl_response_code}" "200"
 		end
 
+		it "Allows configuration of an alternative Apache MPM (event)."
+			local status_apache_mpm_changed=""
+
+			docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_MPM="event" \
+				--hostname app-1.local \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c "apachectl -V | grep -qE '^Server MPM:[ ]+event$'"
+
+			status_apache_mpm_changed=${?}
+
+			assert equal "${status_apache_mpm_changed}" 0
+		end
+
 		docker_terminate_container apache-php.pool-1.1.1 &> /dev/null
 		trap - \
 			INT TERM EXIT

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -757,7 +757,6 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			docker run -d \
 				--name apache-php.pool-1.1.1 \
-				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 				--env APACHE_LOAD_MODULES="authz_core_module authz_user_module log_config_module expires_module deflate_module filter_module headers_module setenvif_module socache_shmcb_module mime_module status_module dir_module alias_module unixd_module version_module proxy_module proxy_fcgi_module rewrite_module" \
 				jdeathe/centos-ssh-apache-php:latest \
 			&> /dev/null

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## Functional
+
+### Installation
+
+The functional test cases are written in [shpec](https://github.com/rylnd/shpec). 
+
+To run the tests install shpec with the installer.
+
+```
+$ bash -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
+```
+
+### Usage
+
+To manually run the test cases, from the project root:
+
+```
+$ SHPEC_ROOT=test/shpec shpec
+```


### PR DESCRIPTION
- Adds updated source image to [1.7.5 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.7.5).
- Adds reduced number of image layers.
- Adds a Change Log.
- Adds support for semantic version numbered tags.
- Adds minor code style changes to the Makefile.
- Adds test cases using [shpec](https://github.com/rylnd/shpec), run with `make test`.