### PR TITLE
CLOSES #295: Update source to centos-6-1.7.5 release tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,274 @@
+# Change Log
+
+## centos-6
+
+Summary of release changes for Version 1.
+
+CentOS-6 6.8 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
+
+### 1.8.1 - 2016-10-27
+
+- Adds updated README with details of new 2.0.0 release tag.
+- Adds updated image tag pattern rules required for the new `centos-6-httpd24u-php56u` based tags.
+
+### 1.8.0 - 2016-10-25
+
+- Adds installation of php-hello-world app from [external release source](https://github.com/jdeathe/php-hello-world/releases).
+- Adds UseCanonicalName On httpd setting.
+- Adds reduced Dockerfile build layers for installing PHP app package.
+- Adds startup script `/usr/sbin/httpd-startup` used to initialise environment variables; paths that are relative are expanded to absolute and the hostname placeholder is replaced with the container's hostname. This logic has been moved out of the Apache wrapper script so it can be set globally and made available when accessing the container interactively.
+- Adds package php-hello-world 0.4.0.
+- Adds update browser screenshots to documentation.
+
+### 1.7.3 - 2016-10-02
+
+- Adds Makefile help target with usage instructions.
+- Splits up the Makefile targets into internal and public types.
+- Adds correct `scmi` path in usage instructions.
+- Changes `PACKAGE_PATH` to `DIST_PATH` in line with the Makefile environment include. Not currently used by `scmi` but changing for consistency.
+- Changes `DOCKER_CONTAINER_PARAMETERS_APPEND` to `DOCKER_CONTAINER_OPTS` for usability. This is a potentially breaking change that could affect systemd service configurations if using the Environment variable in a drop-in customisation. However, if using the systemd template unit-files it should be pinned to a specific version tag. The Makefile should only be used for development/testing and usage in `scmi` is internal only as the `--setopt` parameter is used to build up the optional container parameters. 
+- Removes X-Fleet section from template unit-file.
+
+### 1.7.2 - 2016-09-30
+
+- Updates source to release centos-6-1.7.2.
+- Replaces `PACKAGE_PATH` with `DIST_PATH` in Makefile. The package output directory created will be `./dist` instead of `./packages/jdeathe`.
+- Apache VirtualHost configuration has been simplified to only require a single certificate bundle file (`/etc/pki/tls/certs/localhost.crt`) in PEM format.
+- Adds `APACHE_SSL_CERTIFICATE` to allow the operator to add a PEM, (and optionally base64), encoded certificate bundle (inclusive of key + certificate + intermediate certificate. Base64 encoding of the PEM file contents is recommended.
+- Adds `APACHE_SSL_CIPHER_SUITE` to allow the operator to define a custom CipherSuite.
+- Adds `APACHE_SSL_PROTOCOL` to allow the operator to add/remove SSL protocol support.
+- Adds usage instructions for `APACHE_SSL_CERTIFICATE`, `APACHE_SSL_CIPHER_SUITE` and `APACHE_SSL_PROTOCOL`.
+- Removes requirement to pass php package name to the php-wrapper - feature was undocumented and unused.
+- Removes MySQL legacy-linked environment variable population and handling.
+- Adds correct path to `scmi` in image metadata to allow `atomic install` to complete successfully.
+
+#### Known Issues
+
+The Makefile install (create) target fails when a `APACHE_SSL_CERTIFICATE` is set as multiline formatted string in the environment as follows.
+
+```
+$ export APACHE_SSL_CERTIFICATE="$(
+  < "/etc/pki/tls/certs/localhost.crt"
+)"
+```
+
+The recommended way to set the certificate value is to base64 encode it as a string value.
+
+Mac OSX:
+
+```
+$ export APACHE_SSL_CERTIFICATE="$(
+  base64 -i "/etc/pki/tls/certs/localhost.crt"
+)"
+```
+
+Linux:
+
+```
+$ export APACHE_SSL_CERTIFICATE="$(
+  base64 -w 0 -i "/etc/pki/tls/certs/localhost.crt"
+)"
+```
+
+### 1.7.1 - 2016-09-14
+
+- Adds scmi configuration + systemd template unit-files to image.
+- Removes unnecessary step to re-add scmi to the image.
+- Removes unused create/run template used by the Makefile.
+- Updated README with some minor corrections and changes for consistency.
+
+### 1.7.0 - 2016-09-13
+
+- Updates upstream source to centos-6.1.7.0.
+- Adds `scmi` and metadata for atomic install/uninstall usage.
+- Removes deprecated run.sh and build.sh helper scripts. These have been replaced with the make targets `make` (or `make build`) and `make install start`.
+- Removes support for and documentation on configuration volumes. These can still be implemented by making use of the `DOCKER_CONTAINER_PARAMETERS_APPEND` environment variable or using the `scmi` option `--setopt` to append additional docker parameters to the default docker create template.
+- Changes systemd template unit-file environment variable for `DOCKER_IMAGE_PACKAGE_PATH` now defaults to the path `/var/opt/scmi/packages` instead of `/var/services-packages` however this can be reverted back using the `scmi` option `--env='DOCKER_IMAGE_PACKAGE_PATH="/var/services-packages"'` if necessary.
+- Replaces `HTTPD` with `APACHE_MPM`; instead of needing to supply the path to the correct binary `APACHE_MPM` takes the Apache MPM name (i.e. `prefork` or `worker`).
+- Replaces `SERVICE_UID` with `APACHE_HEADER_X_SERVICE_UID`.
+- Default to using the `{{HOSTNAME}}` placeholder for the value of `APACHE_HEADER_X_SERVICE_UID`.
+- Adds the `/usr/sbin/httpd-wrapper` script to make the wrapper more robust and simpler to maintain that the one-liner that was added directly using the supervisord program command.
+- Adds Lockfile handling into the `/usr/sbin/httpd-bootstrap` script making it more robust and simpler to maintain.
+- Adds a minor correction to a couple of the README `scmi` examples.
+- Reviewed quoting of environment variables used in Apache include templates and in the bootstrap script.
+- To be consistent with other `jdeathe/centos-ssh` based containers the default group used in the docker name has been changed to `pool-1` from `app-1`.
+- Adds a niceness value of 10 to the httpd process in the httpd-wrapper script.
+- Stops header X-Service-UID being set if `APACHE_HEADER_X_SERVICE_UID` is empty.
+- Adds support for defining `APACHE_CUSTOM_LOG_LOCATION` and `APACHE_ERROR_LOG_LOCATION` paths that are relative to `APACHE_CONTENT_ROOT`. This allows for a simplified configuration.
+- Prevents `scmi` installer publishing port 443 if `APACHE_MOD_SSL_ENABLED` is false.
+- Adds a fix for the default value of `APACHE_HEADER_X_SERVICE_UID` when using `scmi`.
+- Adds method to prevent exposed ports being published when installing using the embedded `scmi` installation method or the Makefile's create/run template. e.g. To prevent port `8443` getting published set the value of the environment variable `DOCKER_PORT_MAP_TCP_8443` to `NULL`
+- Disables publishing port `8443` by default in scmi/make/systemd install templates.
+
+### 1.6.1 - 2016-09-09
+
+- Adds default of `expose_php = Off` even if the user configuration is not loaded.
+- Adds `PACKAGE_PATH` environment variable to the bootstrap.
+- Loading of app PHP configuration is now carried out in the bootstrap before starting `httpd` (Apache) and not as an image build time step. This is necessary to allow the environment variables to be replaced before being loaded by the fcgid php-wrapper script where the environment is cleared down.
+- Removes redundant image build step. This should have been removed before release of 1.6.0
+- Adds app package fcgid configuration. Used when building with fcgid support.
+- Adds loading of Apache app package configuration files into the bootstrap.
+- Removes a now redundant image build step.
+- Adds enable/disable of the SSL VirtualHost configuration into the bootstrap.
+
+### 1.6.0 - 2016-09-08
+
+- Adds fix for issues running `make dist` before creating package path.
+- Adds fix for incorrect etcd key/value path in systemd template unit-file.
+- Relocates VirtualHost configuration out of app package and into the container package.
+- Adds simplified php-wrapper script now that configuration is handled by the php.d/\*ini scan directory includes.
+- Adds restructured httpd configuration. Replaced the single template VirtualHost that was used to generate an SSL copy using the bootstrap script with 2 basic VirtualHost definitions. The majority of configuration is now pulled in from the scan directory `/etc/services-config/httpd/conf.d/*.conf` where core container configuration is prefixed with `00-`. App package configuration (`/var/www/app/etc/httpd/conf.d/*.conf`) files are added to this directory as part of the container build and prefixed with `50-` to indicate their source and influence load order.
+- Adds the PHP Info script into the demo app package the source instead of generating it as part of the container build.
+- Adds an increased MaxKeepAliveRequests value of 200 from the default 100.
+- Removes some unused configuration scripts.
+- Fixes an issue with the php-wrapper script not loading in the configuration environment variables from `/etc/httpd-bootstrap.conf`.
+- Adds minor improvement to the demo app's index.php to prevent errors if either the PHP Info or  APC Info scripts are unavailable.
+- The placeholder `{{HOSTNAME}}` will be replaced with the system (container) hostname when used in the value of the environment variable `SERVICE_UID`.
+
+### 1.5.0 - 2016-09-04
+
+- Updates upstream source tag to `centos-6-1.6.0` (i.e. Updated to CentOS-6.8).
+- Adds `APACHE_OPERATING_MODE` to the systemd run command.
+- Disables the default Apache DocumentRoot `/var/www/html`.
+- Disables the `TRACE` method in the VirtualHost configuration.
+- Updates examples in README.
+- Updates SSL configuration to use 2048 bit key size to reduce CPU usage.
+- Enables `SSLSessionCache` in the VirtualHost configuration.
+- Updates SSL configuration to use Mozilla recommended cipher suites and order.
+- Maintenance: Use single a line ENV to set all environment variables.
+- Fixes an issue with log paths being incorrect due to `APACHE_CONTENT_ROOT` being undefined.
+- Removes use of "AllowOverride All" in the VirtualHost configuration when no .htaccess exists in the DocumentRoot path. This would otherwise log the following error: "(13)Permission denied: /var/www/app/public_html/.htaccess pcfg_openfile: unable to check htaccess file, ensure it is readable"
+- Adds Makefile to replace build.sh and run.sh
+- Updates systemd template unit-files.
+- Updates and relocates bootstrap script.
+- Restructures supervisord configuration and adds improvements to bootstrap reliability.
+
+### 1.4.5 - 2016-04-25
+
+- Fixed issue with httpd.conf syntax errors on startup if using a named data volume mapping to /var/www instead of /var/www/app - which results in /var/www/html being unavailable.
+- Disable TRACE method globally. It's only required for debugging so can be enabled in the VirtualHost if necessary.
+- Fixed issue with duplicate comment characters in /etc/sysconfig/httpd.
+- Use `etc/services-config/php/php.d/00-php.ini` and `var/www/app/etc/php.d/50-php.ini` to define Global and Application PHP settings.
+- Added Apache configuration parameter `APACHE_OPERATING_MODE` for production,development and debug modes.
+- Prevent invalid or unavailable Apache module identifiers in the apache-bootstrap.
+- Use a single environment variable `SERVICE_UID` to define the 'X-Service-Uid' Header value. This replaces the use of `SERVICE_UNIT_INSTANCE`, `SERVICE_UNIT_LOCAL_ID`, and `SERVICE_UNIT_INSTANCE`.
+
+VirtualHost improvements:
+- Added correct MIME type for .ico, opentype and web fonts not defined in /etc/mime.types.
+- Added correct encoding for svgz filetype.
+- Identify known cases of invalidated Accept-Encoding request headers.
+- Expand on the filetypes that should be output compressed.
+- Expand on the filetypes that should set a 7 day expires header.
+- Added Cache-Control header to allow browser to cache 204 /favicon.ico responses. Appears to only work over HTTP protocol.
+
+### 1.4.4 - 2016-03-10
+
+- Improved self-signed certificate generation.
+- Increased process limits to 85 soft a 170 hard.
+- Sort the Apache modules in log output.
+- Added php-wrapper to the app source.
+- Locate the fcgid php-wrapper script within the package directory.
+- Remove VirtualHost configuration that can be added to fcgid.conf instead.
+- Deprecate `APACHE_SUEXEC_USER_GROUP` which is not necessary in containerised app after adding support for `APACHE_RUN_USER` and `APACHE_RUN_GROUP`.
+
+### 1.4.3 - 2016-03-04
+
+- Fixed issue with thread limit being too restrictive.
+- Improved systemd install script.
+- Added app group to the apache system user account.
+- Corrected app root/install directory permissions.
+- No longer display SSL certificate that is later removed in the docker build output.
+- Generate the SSL VirtualHost configuration file only when required; do not store a copy unnecessarily.
+- Fixed server-status Location in repository copy of httpd.conf (not an issue in container build).
+- Added `APACHE_RUN_USER` and `APACHE_RUN_GROUP` to define the account which Apache runs under. Thread limits are now defined for the apache group instead of by username.
+- Use system user accounts instead of standard accounts and use names instead of UID/GID values where applicable.
+- Removed `SERVICE_USER_GROUP` in favour of `APACHE_RUN_USER`.
+- Removed `SERVICE_USER_PASSWORD` and prevent display of system account passwords from logs.
+- Prevent attempts to change system user login to that of existing user.
+- Prevent the root/install directory being populated with the user skeleton directory (/etc/skel) contents.
+- Remove symbolic link `/home/app` to the root/install directory.
+- Include app directory structure in the source instead of creating empty directories as a build step.
+- Updated "Hello, world!" app index.php to Bootstrap 3.3.6 from 3.1.1.
+- Rationalised environment variable names. The deprecated names are still added to the environment to allow existing vhost.conf files that may be stored on container's data volumes to continue to function. Environment variables changes {old-name} => {new-name}:
+  - `APP_HOME_DIR` => `APACHE_CONTENT_ROOT`
+  - `DATE_TIMEZONE` => `PHP_OPTIONS_DATE_TIMEZONE`
+  - `SERVICE_USER` => `APACHE_SYSTEM_USER`
+  - `SUEXECUSERGROUP` => `APACHE_SUEXEC_USER_GROUP`
+- Remove requirement for .app-skel; Install to `PACKAGE_PATH` and link to, (or copy if necessary to), `APACHE_CONTENT_ROOT`. Created on first run instead of storing a copy on container.
+- Added `APACHE_PUBLIC_DIRECTORY` to define the public web directory relative to `APACHE_CONTENT_ROOT`.
+- EnableSendfile Apache directive is set to off if DocumentRoot is detected as an `nfs` type file system.
+- Enable TLS > 1.0 and disable RC4-RCA and LOW Cipher Suites in SSL VirtualHost configuration.
+- Reduced initialisation/startup time and reduced time for docker logs output to appear.
+- Add feature to allow operator to customise Apache access and error log configuration using environment variables.
+
+### 1.4.2 - 2016-01-24
+
+- Updated upstream source tag to 1.4.2.
+- Revised method + instructions on data volume usage.
+- Improved systemd definition file and installation script.
+- Fixed issue with populating app home directory if exists but empty.
+- Reverted change to URI of the Apache status feature from /\_httpdstatus to /server-status. This allows the `apachectl status|fullstatus` commands to function correctly.
+
+### 1.4.1 - 2016-01-23
+
+- Updated source tag to 1.4.1.
+- Implement HTTPD environment variable to allow operator to switch between httpd (Prefork) and httpd.worker (Worker) MPM.
+- Removed references to Composer as it has not been included as part of the container build.
+- Populate the container's /etc/hosts with `APACHE_SERVER_NAME` and `APACHE_SERVER_ALIAS` values.
+- Split out the HTTP and HTTPS configuration includes and comment/uncomment entire block for the SSL configuration instead of targeting each line. _NOTE_ If you are using an existing vhost.conf and want to use the mod_ssl feature of the container instead of terminating the SSL upstream then you should update the mod_ssl configuration to the following (with the '#' at the beginning of the line):
+
+  ```
+  #        <IfModule mod_ssl.c>
+  #                SSLEngine on
+  #                SSLOptions +StrictRequire
+  #                SSLProtocol -all +TLSv1
+  #                SSLCipherSuite ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM
+  #                SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+  #                SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+  #                #SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+  #        </IfModule>
+  ```
+- Add function to set Apache's main ServerName to suppress startup message.
+- Disable ExtendedStatus by default and add environment variable to allow it to be enabled by the operator.
+
+### 1.4.0 - 2015-12-24
+
+- Updated to CentOS 6.7.
+
+### 1.3.1 - 2015-12-23
+
+- Updated upstream image to centos-6-1.3.1 tag.
+- Update packages httpd and mod_ssl.
+- Fixed 'Error: could not find config file /etc/supervisord.conf' being logged on non Darwin docker hosts when using the run.sh helper script.
+- Fixed issue with setting the default tag in the build.sh helper script.
+- Use local scope variables in bash helper script functions.
+- Update bootstrap and vhost.conf for FCGID php-wrapper directory path change.
+- Updated the systemd definition file and installer script. Now using etcd2.
+- Add 'rpm --rebuilddb' before yum install to resolve checksum issues that prevented build completion.
+- Added feature to apply config via environment variables + documentation updated with example use cases.
+- Added Apache module reqtimeout_module.
+
+### 1.3.0 - 2015-07-12
+
+- Build from a specified tag instead of branch.
+- Specify package versions, add versionlock package and lock packages.
+- Locate the SSH configuration file in a subdirectory to be more consistent.
+- Added support for running and building on Mac Docker hosts (when using boot2docker).
+
+### 1.2.1 - 2015-05-25
+
+- Updated the systemd service file to reference the correct tag version.
+- Fixed some spelling errors in the README
+
+### 1.2.0 - 2015-05-04
+
+- Updated to CentOS 6.6 from 6.5
+- Added MIT License
+
+### 1.0.1 - 2014-10-23
+
+- Reduce the number of layers required to build the image. This reduces the chance of hitting the 127 layer limit and should speed up build and pull tasks.
+
+### 1.0.0 - 2014-08-28
+
+- Initial release

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ Targets:
   start                     Start the container in the created state.
   stop                      Stop the container when in a running state.
   terminate                 Unpause, stop and remove the container.
+  test                      Run all test cases.
   unpause                   Unpause the container when in a paused state.
 
 Variables:
@@ -108,10 +109,15 @@ PREFIX_SUB_STEP_POSITIVE := $(shell \
 
 # Package prerequisites
 docker := $(shell \
-	type -p docker \
+	command -v docker \
 )
 xz := $(shell \
-	type -p xz \
+	command -v xz \
+)
+
+# Testing prerequisites
+shpec := $(shell \
+	command -v shpec \
 )
 
 # Used to test docker host is accessible
@@ -131,6 +137,7 @@ get-docker-info := $(shell \
 	_require-docker-image-tag \
 	_require-docker-release-tag \
 	_require-package-path \
+	_test-prerequisites \
 	_usage \
 	all \
 	build \
@@ -155,6 +162,7 @@ get-docker-info := $(shell \
 	start \
 	stop \
 	terminate \
+	test \
 	unpause
 
 _prerequisites:
@@ -172,78 +180,83 @@ endif
 
 _require-docker-container:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
-			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+		echo "$(PREFIX_SUB_STEP)Try removing it with: make rm"; \
+		exit 1; \
+	fi
 
 _require-docker-container-not-status-paused:
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
-			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+		echo "$(PREFIX_SUB_STEP)Try unpausing it with: make unpause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-created:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be created."; \
+		echo "$(PREFIX_SUB_STEP)Try installing it with: make install"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-exited:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
-			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+		echo "$(PREFIX_SUB_STEP)Try stopping it with: make stop"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-paused:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
-			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+		echo "$(PREFIX_SUB_STEP)Try pausing it with: make pause"; \
+		exit 1; \
+	fi
 
 _require-docker-container-status-running:
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
-			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)This operation requires the $(DOCKER_NAME) docker container to be running."; \
+		echo "$(PREFIX_SUB_STEP)Try starting it with: make start"; \
+		exit 1; \
+	fi
 
 _require-docker-image-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		exit 1; \
+	fi
 
 _require-docker-release-tag:
 	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP_NEGATIVE)Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+		echo "$(PREFIX_SUB_STEP)A release tag is required for this operation."; \
+		exit 1; \
+	fi
 
 _require-package-path:
 	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP) Creating package directory"; \
-			mkdir -p $(DIST_PATH); \
-		fi; \
-		if [[ ! $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
-			exit 1; \
-		elif [[ -z $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_STEP)Creating package directory"; \
+		mkdir -p $(DIST_PATH); \
+	fi; \
+	if [[ ! $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Failed to make package path: $(DIST_PATH)"; \
+		exit 1; \
+	elif [[ -z $(DIST_PATH) ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Undefined DIST_PATH"; \
+		exit 1; \
+	fi
+
+_test-prerequisites:
+ifeq ($(shpec),)
+	$(error "Please install shpec.")
+endif
 
 _usage:
 	@: $(info $(USAGE))
@@ -252,81 +265,81 @@ all: _prerequisites | build images install start ps
 
 # build NO_CACHE=[{false,true}]
 build: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
+	@ echo "$(PREFIX_STEP)Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 	@ if [[ $(NO_CACHE) == true ]]; then \
-			echo "$(PREFIX_SUB_STEP) Skipping cache"; \
-		fi
+		echo "$(PREFIX_SUB_STEP)Skipping cache"; \
+	fi
 	@ $(docker) build \
-			--no-cache=$(NO_CACHE) \
-			-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
-			.; \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Build complete"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Build error"; \
-			exit 1; \
-		fi
+		--no-cache=$(NO_CACHE) \
+		-t $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) \
+		.; \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Build complete"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Build error"; \
+		exit 1; \
+	fi
 
 clean: _prerequisites | terminate rmi
 
 create: _prerequisites _require-docker-container-not
-	@ echo "$(PREFIX_STEP) Creating container"
+	@ echo "$(PREFIX_STEP)Creating container"
 	@ set -x; \
-		$(docker) create \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) create \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container created"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container creation failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container created"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container creation failed"; \
+		exit 1; \
+	fi
 
 dist: _prerequisites _require-docker-release-tag _require-package-path | pull
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Saving package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
+		echo "$(PREFIX_STEP)Saving package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Package already exists"; \
+	else \
+		echo "$(PREFIX_STEP)Saving package"; \
+		$(docker) save \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
+			$(xz) -9 > \
+				$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
+		if [[ $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package saved"; \
 		else \
-			echo "$(PREFIX_STEP) Saving package"; \
-			$(docker) save \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
-				$(xz) -9 > \
-					$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
-				if [[ $${?} -eq 0 ]]; then \
-					echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
-				else \
-					echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
-					exit 1; \
-				fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package save error"; \
+			exit 1; \
+		fi; \
+	fi
 
 distclean: _prerequisites _require-docker-release-tag _require-package-path | clean
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ if [[ -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP) Deleting package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			find $($@_dist_path) \
-				-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
-				-delete; \
-			if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
-				exit 1; \
-			fi; \
+		echo "$(PREFIX_STEP)Deleting package"; \
+		echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		find $($@_dist_path) \
+			-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
+			-delete; \
+		if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Package cleanup complete"; \
 		else \
-			echo "$(PREFIX_STEP) Package cleanup skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Package cleanup failed"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP)Package cleanup skipped"; \
+	fi
 
 exec: _prerequisites
 	@ $(docker) exec -it $(DOCKER_NAME) $(filter-out $@, $(MAKECMDGOALS))
@@ -334,7 +347,7 @@ exec: _prerequisites
 
 images: _prerequisites
 	@ $(docker) images \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
 
 help: _usage
 
@@ -351,142 +364,149 @@ load: _prerequisites _require-docker-release-tag _require-package-path
 	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
-	@ echo "$(PREFIX_STEP) Loading image from package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
-			exit 1; \
-		else \
-			$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
-				$(docker) load; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
-		fi
+	@ echo "$(PREFIX_STEP)Loading image from package"; \
+	echo "$(PREFIX_SUB_STEP)Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+	if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+		echo "$(PREFIX_STEP_NEGATIVE)Package not found"; \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
+		exit 1; \
+	else \
+		$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
+			$(docker) load; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image loaded"; \
+	fi
 
 pause: _prerequisites _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Pausing container"
+	@ echo "$(PREFIX_STEP)Pausing container"
 	@ $(docker) pause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container paused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container paused"
 
 pull: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Pulling image from registry"
+	@ echo "$(PREFIX_STEP)Pulling image from registry"
 	@ $(docker) pull \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
-		if [[ $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Image pulled"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Error pulling image"; \
-			exit 1; \
-		fi
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
+	if [[ $${?} -eq 0 ]]; then \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;)"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Image pulled"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Error pulling image"; \
+		exit 1; \
+	fi
 
 ps: _prerequisites _require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
 
 restart: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Restarting container"
+	@ echo "$(PREFIX_STEP)Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container restarted"
 
 rm: _prerequisites _require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container removal skipped"; \
+		echo "$(PREFIX_STEP)Container removal skipped"; \
+	else \
+		echo "$(PREFIX_STEP)Removing container"; \
+		$(docker) rm -f $(DOCKER_NAME); \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container removed"; \
 		else \
-		  echo "$(PREFIX_STEP) Removing container"; \
-			$(docker) rm -f $(DOCKER_NAME); \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-					echo "$(PREFIX_SUB_STEP_POSITIVE) Container removed"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container removal failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container removal failed"; \
+			exit 1; \
+		fi; \
+	fi
 
 rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
-	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
-			echo "$(PREFIX_STEP) Untagging image"; \
-			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
-			$(docker) rmi \
-				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
-			if [[ $${?} -eq 0 ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Image untagged"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error untagging image"; \
-				exit 1; \
-			fi; \
+	@ if [[ -n $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) ]]; then \
+		echo "$(PREFIX_STEP)Untagging image"; \
+		echo "$(PREFIX_SUB_STEP)$$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi;) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
+		$(docker) rmi \
+			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null; \
+		if [[ $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Image untagged"; \
 		else \
-			echo "$(PREFIX_STEP) Untagging image skipped"; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error untagging image"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "$(PREFIX_STEP)Untagging image skipped"; \
+	fi
 
 run: _prerequisites _require-docker-image-tag
-	@ echo "$(PREFIX_STEP) Running container"
+	@ echo "$(PREFIX_STEP)Running container"
 	@ set -x; \
-		$(docker) run \
-			--detach \
-			$(DOCKER_CONTAINER_PARAMETERS) \
-			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_OPTS) \
-			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
+	$(docker) run \
+		--detach \
+		$(DOCKER_CONTAINER_PARAMETERS) \
+		$(DOCKER_PUBLISH) \
+		$(DOCKER_CONTAINER_OPTS) \
+		$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container running"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container run failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP)$$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container running"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container run failed"; \
+		exit 1; \
+	fi
 
 start: _prerequisites _require-docker-container _require-docker-container-not-status-paused
-	@ echo "$(PREFIX_STEP) Starting container"
+	@ echo "$(PREFIX_STEP)Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
-			&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) start $(DOCKER_NAME) 1> /dev/null; \
-		fi
+		&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+		$(docker) start $(DOCKER_NAME) 1> /dev/null; \
+	fi
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_SUB_STEP_POSITIVE) Container started"; \
-		else \
-			echo "$(PREFIX_SUB_STEP_NEGATIVE) Container start failed"; \
-			exit 1; \
-		fi
+		echo "$(PREFIX_SUB_STEP_POSITIVE)Container started"; \
+	else \
+		echo "$(PREFIX_SUB_STEP_NEGATIVE)Container start failed"; \
+		exit 1; \
+	fi
 
 stop: _prerequisites _require-docker-container-not-status-paused _require-docker-container-status-running
-	@ echo "$(PREFIX_STEP) Stopping container"
+	@ echo "$(PREFIX_STEP)Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container stopped"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Error stopping container"; \
-				exit 1; \
-			fi; \
-		fi
+		$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container stopped"; \
+		else \
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Error stopping container"; \
+			exit 1; \
+		fi; \
+	fi
 
 terminate: _prerequisites
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP) Container termination skipped"; \
+		echo "$(PREFIX_STEP)Container termination skipped"; \
+	else \
+		echo "$(PREFIX_STEP)Terminating container"; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Unpausing container"; \
+			$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Stopping container"; \
+			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP)Removing container"; \
+			$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
+		fi; \
+		if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_SUB_STEP_POSITIVE)Container terminated"; \
 		else \
-			echo "$(PREFIX_STEP) Terminating container"; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Unpausing container"; \
-				$(docker) unpause $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Stopping container"; \
-				$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP) Removing container"; \
-				$(docker) rm -f $(DOCKER_NAME) 1> /dev/null; \
-			fi; \
-			if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-				echo "$(PREFIX_SUB_STEP_POSITIVE) Container terminated"; \
-			else \
-				echo "$(PREFIX_SUB_STEP_NEGATIVE) Container termination failed"; \
-				exit 1; \
-			fi; \
-		fi
+			echo "$(PREFIX_SUB_STEP_NEGATIVE)Container termination failed"; \
+			exit 1; \
+		fi; \
+	fi
+
+test: _test-prerequisites
+	@ if [[ -z $$(if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):latest); fi;) ]]; then \
+		$(MAKE) build; \
+	fi;
+	@ echo "$(PREFIX_STEP)Functional test";
+	@ SHPEC_ROOT=$(SHPEC_ROOT) $(shpec);
 
 unpause: _prerequisites _require-docker-container-status-paused
-	@ echo "$(PREFIX_STEP) Unpausing container"
+	@ echo "$(PREFIX_STEP)Unpausing container"
 	@ $(docker) unpause $(DOCKER_NAME) 1> /dev/null
-	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container unpaused"
+	@ echo "$(PREFIX_SUB_STEP_POSITIVE)Container unpaused"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ Apache PHP web server, loading only a minimal set of Apache modules by default. 
 
 ## Overview & links
 
-- centos-6 [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/Dockerfile)
-- centos-6-httpd24u-php56u [(centos-6-httpd24u-php56u/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6-httpd24u-php56u/Dockerfile)
+### Tags and respective `Dockerfile` links
+
+- `centos-6-httpd24u-php56u`, `centos-6-httpd24u-php56u-2.0.0`, `2.0.0` [(centos-6-httpd24u-php56u/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6-httpd24u-php56u/Dockerfile)
+- `centos-6`, `centos-6-1.8.0`, `1.8.0` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-apache-php/blob/centos-6/Dockerfile)
 
 #### centos-6
 
-The latest CentOS-6 Standard Package based release can be pulled from the `centos-6` Docker tag. For a specific release tag the convention is `centos-6-1.8.0` for the [1.8.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/1.8.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd CentOS package), uses the mpm_prefork_module and php5_module modules for handling [PHP](http://php.net/).
+The latest CentOS-6 Standard Package based release can be pulled from the `centos-6` Docker tag. It is recommended to select a specific release tag - the convention is `centos-6-1.8.0` or `1.8.0` for the [1.8.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/1.8.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd CentOS package), uses the mpm_prefork_module and php5_module modules for handling [PHP](http://php.net/).
 
 #### centos-6-httpd24u-php56u
 
-The latest CentOS-6 [IUS](https://ius.io) Apache 2.4, PHP-FPM 5.6 based release can be pulled from the `centos-6-httpd24u-php56u` Docker tag. For a specific release tag the convention is `centos-6-httpd24u-php56u-2.0.0` for the [2.0.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/2.0.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd24u package), uses the mpm_prefork_module and php-fpm for handling [PHP](http://php.net/). This version has the option of using the worker or event MPM.
+The latest CentOS-6 [IUS](https://ius.io) Apache 2.4, PHP-FPM 5.6 based release can be pulled from the `centos-6-httpd24u-php56u` Docker tag. It is recommended to select a specific release tag - the convention is `centos-6-httpd24u-php56u-2.0.0` or `2.0.0` for the [2.0.0](https://github.com/jdeathe/centos-ssh-apache-php/tree/2.0.0) release tag. This build of [Apache](https://httpd.apache.org/), (httpd24u package), uses the mpm_prefork_module and php-fpm for handling [PHP](http://php.net/). This version has the option of using the worker or event MPM.
 
 Included in the build are the [SCL](https://www.softwarecollections.org/), [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), [elinks](http://elinks.or.cz) (for fullstatus support), PHP [Memcached](http://pecl.php.net/package/memcached) are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout). The `centos-6` "Standard" PHP 5.3 build includes PHP [APC](http://pecl.php.net/package/APC) where Zend Opcache is bundled in  PHP 5.6.
 

--- a/environment.mk
+++ b/environment.mk
@@ -3,10 +3,11 @@
 # -----------------------------------------------------------------------------
 DOCKER_USER := jdeathe
 DOCKER_IMAGE_NAME := centos-ssh-apache-php
+SHPEC_ROOT := test/shpec
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$
-DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$
+DOCKER_IMAGE_TAG_PATTERN := ^(latest|centos-[6-7]|centos-6-httpd24u-php56u|(([1-3]|centos-(6-1|6-httpd24u-php56u-2|7-3))\.[0-9]+\.[0-9]+))$
+DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^(1|2|centos-(6-1|6-httpd24u-php56u-2))\.[0-9]+\.[0-9]+$
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -3,10 +3,11 @@
 # -----------------------------------------------------------------------------
 DOCKER_USER=jdeathe
 DOCKER_IMAGE_NAME=centos-ssh-apache-php
+SHPEC_ROOT=test/shpec
 
 # Tag validation patterns
-DOCKER_IMAGE_TAG_PATTERN='^(latest|(centos-[6-7])|centos-6-httpd24u-php56u|(centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+))$'
-DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|6-httpd24u-php56u-2|7-3).[0-9]+.[0-9]+$'
+DOCKER_IMAGE_TAG_PATTERN='^(latest|centos-[6-7]|centos-6-httpd24u-php56u|(([1-3]|centos-(6-1|6-httpd24u-php56u-2|7-3))\.[0-9]+\.[0-9]+))$'
+DOCKER_IMAGE_RELEASE_TAG_PATTERN='^(1|2|centos-(6-1|6-httpd24u-php56u-2))\.[0-9]+\.[0-9]+$'
 
 # -----------------------------------------------------------------------------
 # Variables

--- a/test/shpec/makefile.sh
+++ b/test/shpec/makefile.sh
@@ -1,0 +1,114 @@
+describe "Makefile"
+	readonly DOCKER_NAME="makefile_test"
+
+	it "builds the image"
+		local status_make_build
+
+		make build &> /dev/null
+		status_make_build=${?}
+
+		assert equal ${status_make_build} 0
+	end
+
+	it "creates the container"
+		local status_make_install
+
+		make install &> /dev/null
+		status_make_install=${?}
+
+		assert equal ${status_make_install} 0
+	end
+
+	it "starts the container"
+		local status_make_start
+
+		make start &> /dev/null
+		status_make_start=${?}
+
+		assert equal ${status_make_start} 0
+	end
+
+	it "pauses the container"
+		local status_make_pause
+
+		make pause &> /dev/null
+		status_make_pause=${?}
+
+		assert equal ${status_make_pause} 0
+	end
+
+	it "unpauses the container"
+		local status_make_unpause
+
+		make unpause &> /dev/null
+		status_make_unpause=${?}
+
+		assert equal ${status_make_unpause} 0
+	end
+
+	it "restarts the container"
+		local status_make_restart
+
+		make restart &> /dev/null
+		status_make_restart=${?}
+
+		assert equal ${status_make_restart} 0
+	end
+
+	it "outputs the container logs"
+		local status_make_logs
+		local content_make_logs
+
+		content_make_logs=$(
+			make logs
+		)
+		status_make_logs=${?}
+
+		assert equal ${status_make_logs} 0
+	end
+
+	it "terminates the container"
+		local status_make_terminate
+
+		make terminate &> /dev/null
+		status_make_terminate=${?}
+
+		assert equal ${status_make_terminate} 0
+	end
+
+	it "runs the container"
+		local status_make_run
+
+		make run &> /dev/null
+		status_make_run=${?}
+
+		assert equal ${status_make_run} 0
+	end
+
+	it "stops the container"
+		local status_make_stop
+
+		make stop &> /dev/null
+		status_make_stop=${?}
+
+		assert equal ${status_make_stop} 0
+	end
+
+	it "deletes the container"
+		local status_make_rm
+	
+		make rm &> /dev/null
+		status_make_rm=${?}
+	
+		assert equal ${status_make_rm} 0
+	end
+
+	it "untags the image"
+		local status_make_clean
+	
+		make rmi &> /dev/null
+		status_make_clean=${?}
+	
+		assert equal ${status_make_clean} 0
+	end
+end

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,0 +1,1468 @@
+readonly BOOTSTRAP_BACKOFF_TIME=3
+readonly DOCKER_HOSTNAME="localhost"
+readonly TEST_DIRECTORY="test"
+
+# These should ideally be a static value but hosts might be using this port so 
+# need to allow for alternatives.
+DOCKER_PORT_MAP_TCP_22="${DOCKER_PORT_MAP_TCP_22:-NULL}"
+DOCKER_PORT_MAP_TCP_80="${DOCKER_PORT_MAP_TCP_80:-8080}"
+DOCKER_PORT_MAP_TCP_443="${DOCKER_PORT_MAP_TCP_443:-9443}"
+DOCKER_PORT_MAP_TCP_8443="${DOCKER_PORT_MAP_TCP_8443:-NULL}"
+
+function docker_terminate_container ()
+{
+	local CONTAINER="${1}"
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" \
+		--filter "status=paused" &> /dev/null; then
+		docker unpause ${CONTAINER} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" \
+		--filter "status=running" &> /dev/null; then
+		docker stop ${CONTAINER} &> /dev/null
+	fi
+
+	if docker ps -aq \
+		--filter "name=${CONTAINER}" &> /dev/null; then
+		docker rm -vf ${CONTAINER} &> /dev/null
+	fi
+}
+
+function test_setup ()
+{
+	# Generate a self-signed certificate
+	openssl req \
+		-x509 \
+		-sha256 \
+		-nodes \
+		-newkey rsa:2048 \
+		-days 365 \
+		-subj "/CN=www.app-1.local" \
+		-keyout /tmp/www.app-1.local.pem \
+		-out /tmp/www.app-1.local.pem \
+	&> /dev/null
+}
+
+if [[ ! -d ${TEST_DIRECTORY} ]]; then
+	printf -- \
+		"ERROR: Please run from the project root.\n" \
+		>&2
+	exit 1
+fi
+
+describe "jdeathe/centos-ssh-apache-php:latest"
+	test_setup
+
+	describe "Basic Apache PHP operations"
+		trap "docker_terminate_container apache-php.pool-1.1.1 &> /dev/null" \
+			INT TERM EXIT
+
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
+
+		it "Runs an Apache PHP container named apache-php.pool-1.1.1 on port ${DOCKER_PORT_MAP_TCP_80}."
+			local container_hostname=""
+			local container_port_80=""
+			local header_server=""
+			local header_x_service_uid=""
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			container_hostname="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					hostname
+			)"
+
+			container_port_80="$(
+				docker port \
+					apache-php.pool-1.1.1 \
+					80/tcp
+			)"
+			container_port_80=${container_port_80##*:}
+
+			if [[ ${DOCKER_PORT_MAP_TCP_80} == 0 ]] \
+				|| [[ -z ${DOCKER_PORT_MAP_TCP_80} ]]; then
+				assert gt \
+					"${container_port_80}" \
+					"30000"
+			else
+				assert equal \
+					"${container_port_80}" \
+					"${DOCKER_PORT_MAP_TCP_80}"
+			fi
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			it "Responds with a Server header of 'Apache' only."
+				header_server="$(
+					curl -sI \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80} \
+					| grep '^Server: ' \
+					| cut -c 9- \
+					| tr -d '\r'
+				)"
+
+				assert equal \
+					"${header_server}" \
+					"Apache"
+			end
+
+			it "Responds with a X-Service-UID header of the container hostname."
+				header_x_service_uid="$(
+					curl -sI \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80} \
+					| grep '^X-Service-UID: ' \
+					| cut -c 16- \
+					| tr -d '\r'
+				)"
+
+				assert equal \
+					"${header_x_service_uid}" \
+					"${container_hostname}"
+			end
+
+			it "Outputs Apache Details in the docker logs."
+				local apache_details_title=""
+
+				apache_details_title="$(
+					docker logs \
+						apache-php.pool-1.1.1 \
+					| grep '^Apache Details' \
+					| tr -d '\r'
+				)"
+
+				assert equal \
+					"${apache_details_title}" \
+					"Apache Details"
+
+				it "Includes the system user default (app)."
+					local apache_system_user=""
+
+					apache_system_user="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^system user : ' \
+						| cut -c 15- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_system_user}" \
+						"app"
+				end
+
+				it "Includes the run user default (app-www)."
+					local apache_run_user=""
+
+					apache_run_user="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^run user : ' \
+						| cut -c 12- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_run_user}" \
+						"app-www"
+				end
+
+				it "Includes the run group default (app-www)."
+					local apache_run_group=""
+
+					apache_run_group="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^run group : ' \
+						| cut -c 13- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_run_group}" \
+						"app-www"
+				end
+
+				it "Includes the server name default (app-1.local)."
+					local apache_server_name=""
+
+					apache_server_name="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^server name : ' \
+						| cut -c 15- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_server_name}" \
+						"app-1.local"
+				end
+
+				it "Includes the server alias default (EMPTY)."
+					local apache_server_alias=""
+
+					apache_server_alias="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^server alias : ' \
+						| cut -c 16- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_server_alias}" \
+						""
+				end
+
+				it "Includes the header X-Service-UID default ({{HOSTNAME}} replacement)."
+					local apache_header_x_service_uid=""
+
+					apache_header_x_service_uid="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^header x-service-uid : ' \
+						| cut -c 24- \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_header_x_service_uid}" \
+						"${container_hostname}"
+				end
+
+				it "Includes the default document root APACHE_CONTENT_ROOT/APACHE_PUBLIC_DIRECTORY (/var/www/app/public_html)."
+					local apache_document_root=""
+
+					apache_document_root="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep '^document root : ' \
+						| cut -c 17- \
+						| tr -d '\r' \
+						| awk '{ print $1 }'
+					)"
+
+					assert equal \
+						"${apache_document_root}" \
+						"/var/www/app/public_html"
+				end
+
+				# TODO This is included in the logs but not included in the Apache Details.
+				it "Includes the server mpm default (prefork)."
+					local apache_server_mpm=""
+
+					apache_server_mpm="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| grep -o 'Apache Server MPM: .*$' \
+						| cut -c 20- \
+						| awk '{ print tolower($0) }' \
+						| tr -d '\r'
+					)"
+
+					assert equal \
+						"${apache_server_mpm}" \
+						"prefork"
+				end
+
+				it "Includes the default modules enabled."
+					local apache_load_modules=""
+					local apache_load_modules_details=" - alias_module
+ - authz_user_module
+ - deflate_module
+ - dir_module
+ - expires_module
+ - headers_module
+ - log_config_module
+ - mime_module
+ - setenvif_module
+ - status_module"
+
+					apache_load_modules="$(
+						docker logs \
+							apache-php.pool-1.1.1 \
+						| sed -ne \
+							'/^modules enabled :/,/^--+$/ p' \
+							| awk '/^ - /'
+					)"
+
+					assert equal \
+						"${apache_load_modules}" \
+						"${apache_load_modules_details}"
+				end
+			end
+
+			it "Logs to the default access log path (/var/www/app/var/log/apache_access_log)."
+				local apache_access_log_entry=""
+				local curl_get_request=""
+
+				curl_get_request="$(
+					curl -s \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				apache_access_log_entry="$(
+					docker exec \
+						apache-php.pool-1.1.1 \
+						tail -n 1 \
+						/var/www/app/var/log/apache_access_log \
+					| grep -oE \
+						'"GET / HTTP/1\.1" 200' \
+				)"
+
+				assert equal \
+					"${apache_access_log_entry}" \
+					"\"GET / HTTP/1.1\" 200"
+
+				it "Logs using the default LogFormat (combined)."
+					local status_apache_access_log_pattern=""
+
+					docker exec \
+						apache-php.pool-1.1.1 \
+						tail -n 1 \
+						/var/www/app/var/log/apache_access_log \
+					| grep -qE \
+						'^.+ .+ .+ \[.+\] "GET / HTTP/1\.1" 200 .+ ".+" ".*"$' \
+					&> /dev/null
+
+					status_apache_access_log_pattern=${?}
+
+					assert equal \
+						"${status_apache_access_log_pattern}" \
+						0
+				end
+			end
+
+			it "Logs to the default error log path (/var/www/app/var/log/apache_error_log)."
+				local status_apache_error_log_path=""
+				local curl_get_request=""
+
+				curl_get_request="$(
+					curl -s \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				docker exec \
+					apache-php.pool-1.1.1 \
+					tail -n 1 \
+					/var/www/app/var/log/apache_error_log \
+				&> /dev/null
+
+				status_apache_error_log_path=${?}
+
+				assert equal \
+					"${status_apache_error_log_path}" \
+					0
+			end
+
+			it "Apache server-status can be accessed from localhost."
+				local status_apache_server_status_pattern=""
+
+				docker exec \
+					apache-php.pool-1.1.1 \
+					curl -s \
+						http://app-1.local/server-status\?auto \
+				| grep -qE \
+					'^Scoreboard: [\._SRWKDCLGI]+$' \
+				&> /dev/null
+
+				status_apache_server_status_pattern=${?}
+
+				assert equal \
+					"${status_apache_server_status_pattern}" \
+					0
+
+				it "Excludes information available with ExtendedStatus enabled."
+					local status_apache_server_status_pattern=""
+
+					docker exec \
+						apache-php.pool-1.1.1 \
+						curl -s \
+							http://app-1.local/server-status\?auto \
+					| grep -qE \
+						'^Total Accesses: [0-9]+' \
+					&> /dev/null
+
+					status_apache_server_status_pattern=${?}
+
+					# TODO - ISSUE 291: ExtendedStatus should be off by default.
+					# assert equal "${status_apache_server_status_pattern}" 1
+				end
+
+				it "Prevents remote access to server-status."
+					local status_apache_server_status_pattern=""
+					local curl_get_request=""
+
+					curl -s \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80}/server-status\?auto \
+					| grep -qE \
+						'^Scoreboard: [\._SRWKDCLGI]+$' \
+					&> /dev/null
+
+					status_apache_server_status_pattern=${?}
+
+					assert equal \
+						"${status_apache_server_status_pattern}" \
+						1
+
+					it "Responds with a 403 status code."
+						local curl_response_code=""
+
+						curl_response_code="$(
+							curl -s \
+								-o /dev/null \
+								-w "%{http_code}" \
+								--header 'Host: app-1.local' \
+								http://127.0.0.1:${container_port_80}/server-status\?auto
+						)"
+
+						assert equal \
+							"${curl_response_code}" \
+							"403"
+					end
+				end
+			end
+
+			it "Loads all the required Apache modules."
+				readonly required_apache_modules="authz_user_module log_config_module expires_module deflate_module headers_module setenvif_module mime_module status_module dir_module alias_module"
+				readonly other_required_apache_modules="core_module so_module http_module authz_host_module mpm_prefork_module php5_module"
+				local status_apache_modules_loaded=0
+
+				for module in ${required_apache_modules}; do
+					docker exec \
+						apache-php.pool-1.1.1 \
+						bash -c "apachectl -M 2>&1 | grep -q ${module}"
+
+					status_apache_modules_loaded=$((
+						status_apache_modules_loaded + ${?}
+					))
+				done
+
+				assert equal \
+					"${status_apache_modules_loaded}" \
+					0
+
+				it "Loads only the required Apache modules."
+					local all_required_apache_modules="${required_apache_modules} ${other_required_apache_modules}"
+					local all_loaded_apache_modules=""
+					local status_minimal_apache_modules_loaded=""
+
+					all_loaded_apache_modules="$(
+						docker exec \
+							apache-php.pool-1.1.1 \
+							bash -c "apachectl -M 2>&1 | sed -e '/Loaded Modules:/d' -e 's~^ *\([a-z_]*\).*~\1~g'"
+					)"
+
+					for module in ${all_loaded_apache_modules}; do
+						if [[ ! "${all_required_apache_modules}" =~ "${module}" ]]; then
+							status_minimal_apache_modules_loaded=1
+							break
+						fi
+					done
+
+					assert unequal \
+						"${status_minimal_apache_modules_loaded}" \
+						1
+				end
+			end
+
+			it "Runs the using the default user:group (app-www:app-www)."
+				local apache_run_user_group=""
+
+				apache_run_user_group="$(
+					docker exec \
+						apache-php.pool-1.1.1 \
+						ps axo user,group,comm \
+					| grep httpd \
+					| tail -n 1 \
+					| awk '{ print $1":"$2 }'
+				)"
+
+				assert equal \
+					"${apache_run_user_group}" \
+					"app-www:app-www"
+			end
+		end
+
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
+		trap - \
+			INT TERM EXIT
+	end
+
+	describe "Customised Apache PHP configuration"
+		trap "docker_terminate_container apache-php.pool-1.1.1 &> /dev/null" \
+			INT TERM EXIT
+
+		it "Allows configuration of access logs written in common LogFormat."
+			local curl_get_request=""
+			local status_apache_access_log_pattern=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_CUSTOM_LOG_FORMAT="common" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				tail -n 1 \
+				/var/www/app/var/log/apache_access_log \
+			| grep -qE \
+				'^.+ .+ .+ \[.+\] "GET / HTTP/1\.1" 200 .+$' \
+			&> /dev/null
+
+			status_apache_access_log_pattern=${?}
+
+			assert equal \
+				"${status_apache_access_log_pattern}" \
+				0
+		end
+
+		it "Allows configuration of an alternative, relative, access log path."
+			local apache_access_log_entry=""
+			local curl_get_request=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_CUSTOM_LOG_LOCATION="var/log/access.log" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			apache_access_log_entry="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					tail -n 1 \
+					/var/www/app/var/log/access.log \
+				| grep -oE \
+					'"GET / HTTP/1\.1" 200' \
+			)"
+
+			assert equal \
+				"${apache_access_log_entry}" \
+				"\"GET / HTTP/1.1\" 200"
+		end
+
+		it "Allows configuration of an alternative, absolute, access log path."
+			local apache_access_log_entry=""
+			local curl_get_request=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_CUSTOM_LOG_LOCATION="/var/log/httpd/access.log" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			apache_access_log_entry="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					tail -n 1 \
+					/var/log/httpd/access.log \
+				| grep -oE \
+					'"GET / HTTP/1\.1" 200' \
+			)"
+
+			assert equal \
+				"${apache_access_log_entry}" \
+				"\"GET / HTTP/1.1\" 200"
+		end
+
+		it "Allows configuration of an alternative, relative, error log path."
+			local curl_get_request=""
+			local status_apache_error_log_path=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_ERROR_LOG_LOCATION="var/log/error.log" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				tail -n 1 \
+				/var/www/app/var/log/error.log \
+			&> /dev/null
+
+			status_apache_error_log_path=${?}
+
+			assert equal \
+				"${status_apache_error_log_path}" \
+				0
+		end
+
+		it "Allows configuration of an alternative, absolute, error log path."
+			local curl_get_request=""
+			local status_apache_error_log_path=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_ERROR_LOG_LOCATION="/var/log/httpd/error.log" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				tail -n 1 \
+				/var/log/httpd/error.log \
+			&> /dev/null
+
+			status_apache_error_log_path=${?}
+
+			assert equal \
+				"${status_apache_error_log_path}" \
+				0
+		end
+
+		it "Allows configuration of an alternative log level (e.g debug)."
+			local curl_get_request=""
+			local status_apache_error_log_pattern=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_ERROR_LOG_LEVEL="debug" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_get_request="$(
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				tail -n 1 \
+				/var/www/app/var/log/apache_error_log \
+			| grep -qE \
+				' \[debug\] ' \
+			&> /dev/null
+
+			status_apache_error_log_pattern=${?}
+
+			assert equal \
+				"${status_apache_error_log_pattern}" \
+				0
+		end
+
+		it "Allows extended server-status to be enabled and accessed from localhost."
+			local status_apache_server_status_pattern=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_EXTENDED_STATUS_ENABLED="true" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				curl -s \
+					http://app-1.local/server-status\?auto \
+			| grep -qE \
+				'^Total Accesses: [0-9]+' \
+			&> /dev/null
+
+			status_apache_server_status_pattern=${?}
+
+			assert equal \
+				"${status_apache_server_status_pattern}" \
+				0
+
+			it "Prevents remote access to server-status."
+				local status_apache_server_status_pattern=""
+				local curl_get_request=""
+
+				curl -s \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}/server-status\?auto \
+				| grep -qE \
+					'^Total Accesses: [0-9]+' \
+				&> /dev/null
+
+				status_apache_server_status_pattern=${?}
+
+				assert equal \
+					"${status_apache_server_status_pattern}" \
+					1
+
+				it "Responds with a 403 status code."
+					local curl_response_code=""
+
+					curl_response_code="$(
+						curl -s \
+							-o /dev/null \
+							-w "%{http_code}" \
+							--header 'Host: app-1.local' \
+							http://127.0.0.1:${container_port_80}/server-status\?auto
+					)"
+
+					assert equal \
+						"${curl_response_code}" \
+						"403"
+				end
+			end
+		end
+
+		it "Allows configuration of the X-Service-UID header."
+			local header_x_service_uid=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_HEADER_X_SERVICE_UID="host-name@1.2" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			header_x_service_uid="$(
+				curl -sI \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80} \
+				| grep '^X-Service-UID: ' \
+				| cut -c 16- \
+				| tr -d '\r'
+			)"
+
+			assert equal \
+				"${header_x_service_uid}" \
+				"host-name@1.2"
+
+			it "Allows the {{HOSTNAME}} placeholder to be included in the value."
+				local header_x_service_uid=""
+
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
+
+				docker run -d \
+					--name apache-php.pool-1.1.1 \
+					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+					--env APACHE_HEADER_X_SERVICE_UID="{{HOSTNAME}}:${DOCKER_PORT_MAP_TCP_80}" \
+					--hostname app-1.local \
+					jdeathe/centos-ssh-apache-php:latest \
+				&> /dev/null
+
+				sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+				header_x_service_uid="$(
+					curl -sI \
+						--header 'Host: app-1.local' \
+						http://127.0.0.1:${container_port_80} \
+					| grep '^X-Service-UID: ' \
+					| cut -c 16- \
+					| tr -d '\r'
+				)"
+
+				assert equal \
+					"${header_x_service_uid}" \
+					"app-1.local:${DOCKER_PORT_MAP_TCP_80}"
+			end
+		end
+
+		it "Allows for loading of additional modules (e.g. rewrite_module)."
+			local status_apache_module_loaded=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_LOAD_MODULES="authz_user_module log_config_module expires_module deflate_module headers_module setenvif_module mime_module status_module dir_module alias_module rewrite_module" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c "apachectl -M 2>&1 | grep -q rewrite_module"
+
+			status_apache_module_loaded=${?}
+
+			assert equal \
+				"${status_apache_module_loaded}" \
+				0
+		end
+
+		it "Allows configuration of an alternative MPM (e.g. worker)."
+			local status_apache_mpm_changed=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_MPM="worker" \
+				--hostname app-1.local \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c "apachectl -V 2>&1 | grep -qiE '^Server MPM:[ ]+worker$'"
+
+			status_apache_mpm_changed=${?}
+
+			assert equal \
+				"${status_apache_mpm_changed}" \
+				0
+		end
+
+		it "Allows configuration of the operating mode internal variable (i.e -D development)."
+			local header_x_service_operating_mode=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_OPERATING_MODE="development" \
+				--hostname app-1.local \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			header_x_service_operating_mode="$(
+				curl -sI \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80} \
+				| grep '^X-Service-Operating-Mode: ' \
+				| cut -c 27- \
+				| tr -d '\r'
+			)"
+
+			assert equal \
+				"${header_x_service_operating_mode}" \
+				"development"
+		end
+
+		it "Allows configuration of the system user (i.e. application owner)."
+			local apache_system_user=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_SYSTEM_USER="app-user" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_system_user="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					stat -c '%U' /var/www/app/public_html
+			)"
+
+			assert equal \
+				"${apache_system_user}" \
+				"app-user"
+		end
+
+		it "Allows configuration of the run user (i.e. process runner user)."
+			local apache_run_user=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_RUN_USER="runner" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_run_user="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					ps axo user,group,comm \
+				| grep httpd \
+				| tail -n 1 \
+				| awk '{ print $1 }'
+			)"
+
+			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
+			# assert equal "${apache_run_user}" "runner"
+		end
+
+		it "Allows configuration of the run group (i.e. process runner's group)."
+			local apache_run_group=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--env APACHE_RUN_GROUP="runners" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			apache_run_group="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					ps axo user,group,comm \
+				| grep httpd \
+				| tail -n 1 \
+				| awk '{ print $2 }'
+			)"
+
+			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
+			# assert equal "${apache_run_group}" "runners"
+		end
+
+		it "Allows configuration of the ServerName (e.g app-1.local)."
+			local curl_response_code_default=""
+			local curl_response_code_server_named=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_SERVER_NAME="app-1.local" \
+				--env APACHE_SERVER_ALIAS="www.app-1.local" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			# Add a default VirtualHost that rejects access (403 response).
+			docker exec -i \
+				apache-php.pool-1.1.1 \
+				tee \
+					/etc/services-config/httpd/conf.d/05-vhost.conf \
+					1> /dev/null \
+					<<-CONFIG
+			NameVirtualHost *:80
+			NameVirtualHost *:8443
+
+			<VirtualHost *:80 *:8443>
+			    ServerName localhost.localdomain
+			    DocumentRoot /var/www/html
+
+			    <Directory /var/www/html>
+			        ErrorDocument 403 "403 Forbidden"
+			        Order deny,allow
+			        Deny from all
+			    </Directory>
+			</VirtualHost>
+			CONFIG
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				sed -i \
+					-e 's~^NameVirtualHost \(.*\)$~#NameVirtualHost \1~g' \
+					/etc/services-config/httpd/conf.d/10-vhost.conf
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			docker exec \
+				apache-php.pool-1.1.1 \
+				bash -c 'apachectl graceful'
+
+			curl_response_code_default="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			curl_response_code_server_named="$(
+				curl -s \
+					-o /dev/null \
+					-w "%{http_code}" \
+					--header 'Host: app-1.local' \
+					http://127.0.0.1:${container_port_80}
+			)"
+
+			assert equal \
+				"${curl_response_code_default}:${curl_response_code_server_named}" \
+				"403:200"
+
+			it "Allows configuration of a ServerAlias (e.g www.app-1.local)."
+				local curl_response_code_server_alias=""
+
+				curl_response_code_server_alias="$(
+					curl -s \
+						-o /dev/null \
+						-w "%{http_code}" \
+						--header 'Host: www.app-1.local' \
+						http://127.0.0.1:${container_port_80}
+				)"
+
+				assert equal \
+					"${curl_response_code_server_alias}" \
+					"200"
+			end
+		end
+
+		it "Allows configuration of the public directory (e.g web)."
+			local status_header_x_service_uid=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env APACHE_PUBLIC_DIRECTORY="web" \
+				--hostname app-1.local \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			# For the server to start, the public directory needs to match that
+			# which is being configured for the test.
+			docker exec \
+				apache-php.pool-1.1.1 \
+				mv /opt/app/public_html /opt/app/web
+
+			docker restart \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl -sI \
+				--header 'Host: app-1.local' \
+				http://127.0.0.1:${container_port_80} \
+			| grep -q '^X-Service-UID: app-1.local' \
+			&> /dev/null
+
+			status_header_x_service_uid=${?}
+
+			assert equal \
+				"${status_header_x_service_uid}" \
+				0
+		end
+
+		it "Allows configuration of the application's package path."
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env PACKAGE_PATH="/opt/php-hw" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			# For the server to start, the package directory needs to exist.
+			docker exec \
+				apache-php.pool-1.1.1 \
+				mkdir -p /opt/php-hw/{public_html,var/log}
+
+			docker exec -i \
+				apache-php.pool-1.1.1 \
+				tee \
+					/opt/php-hw/public_html/index.php \
+					1> /dev/null \
+					<<-CONFIG
+			<?php
+			    header(
+			        'Content-Type: text/plain; charset=utf-8'
+			    );
+			    print 'Hello, world!';
+			?>
+			CONFIG
+
+			docker restart \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl -s \
+				--header 'Host: app-1.local' \
+				http://127.0.0.1:${container_port_80} \
+			| grep -q '^Hello, world!' \
+			&> /dev/null
+
+			status_php_hello_world=${?}
+
+			assert equal \
+				"${status_php_hello_world}" \
+				0
+		end
+
+		it "Allows ssl_module to be enabled to accept encrypted requests (i.e https)."
+			local container_port_443=""
+			local curl_response_code=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+				--env APACHE_MOD_SSL_ENABLED="true" \
+				--env APACHE_SERVER_NAME="app-1.local" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			container_port_443="$(
+				docker port \
+					apache-php.pool-1.1.1 \
+					443/tcp
+			)"
+			container_port_443=${container_port_443##*:}
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			curl_response_code="$(
+				curl -ks \
+					-o /dev/null \
+					-w "%{http_code}" \
+					--header 'Host: app-1.local' \
+					https://127.0.0.1:${container_port_443}
+			)"
+
+			assert equal \
+				"${curl_response_code}" \
+				"200"
+
+			it "Allows configuration of a certificate instead of auto-generating one on startup."
+				local container_port_443=""
+				local certificate_pem_base64=""
+				local certificate_fingerprint_file=""
+				local certificate_fingerprint_server=""
+
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
+
+				if [[ -s /tmp/www.app-1.local.pem ]]; then
+					certificate_fingerprint_file="$(
+						cat \
+							/tmp/www.app-1.local.pem \
+						| sed \
+							-n \
+							-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
+						| openssl x509 \
+							-fingerprint \
+							-noout \
+						| sed \
+							-e 's~SHA1 Fingerprint=~~'
+					)"
+
+					if [[ $(uname) == "Darwin" ]]; then
+						certificate_pem_base64="$(
+							base64 \
+								-i /tmp/www.app-1.local.pem
+						)"
+					else
+						certificate_pem_base64="$(
+							base64 \
+								-w 0 \
+								-i /tmp/www.app-1.local.pem
+						)"
+					fi
+				fi
+
+				docker run -d \
+					--name apache-php.pool-1.1.1 \
+					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+					--env APACHE_MOD_SSL_ENABLED="true" \
+					--env APACHE_SERVER_NAME="www.app-1.local" \
+					--env APACHE_SSL_CERTIFICATE="${certificate_pem_base64}" \
+					jdeathe/centos-ssh-apache-php:latest \
+				&> /dev/null
+
+				container_port_443="$(
+					docker port \
+						apache-php.pool-1.1.1 \
+						443/tcp
+				)"
+				container_port_443=${container_port_443##*:}
+
+				sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+				certificate_fingerprint_server="$(
+					echo -n \
+					| openssl s_client \
+						-connect 127.0.0.1:${container_port_443} \
+						-CAfile /tmp/www.app-1.local.pem \
+						-nbio \
+						2>&1 \
+					| sed \
+						-n \
+						-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
+					| openssl \
+						x509 \
+						-fingerprint \
+						-noout \
+					| sed \
+						-e 's~SHA1 Fingerprint=~~'
+				)"
+
+				assert equal \
+					"${certificate_fingerprint_server}" \
+					"${certificate_fingerprint_file}"
+			end
+
+			it "Allows configuration of the SSL/TLS cipher suite."
+				local apache_ssl_cipher_suite=""
+				local cipher=""
+				local cipher_match=""
+
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
+
+				docker run -d \
+					--name apache-php.pool-1.1.1 \
+					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+					--env APACHE_MOD_SSL_ENABLED="true" \
+					--env APACHE_SERVER_NAME="www.app-1.local" \
+					--env APACHE_SSL_CERTIFICATE="${certificate_pem_base64}" \
+					--env APACHE_SSL_CIPHER_SUITE="DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA" \
+					jdeathe/centos-ssh-apache-php:latest \
+				&> /dev/null
+
+				container_port_443="$(
+					docker port \
+						apache-php.pool-1.1.1 \
+						443/tcp
+				)"
+				container_port_443=${container_port_443##*:}
+
+				sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+				for cipher in DHE-RSA-AES128-SHA DHE-RSA-AES256-SHA EDH-RSA-DES-CBC3-SHA; do
+					cipher_match="$(
+						echo -n \
+						| openssl s_client \
+							-cipher "${cipher}" \
+							-connect 127.0.0.1:${container_port_443} \
+							-CAfile /tmp/www.app-1.local.pem \
+							-nbio \
+							2>&1 \
+						| grep -o "^[ ]*Cipher[ ]*: ${cipher}$" \
+						| awk '{ print $3 }'
+					)"
+
+					if [[ -n ${cipher_match} ]]; then
+						if [[ -n ${apache_ssl_cipher_suite} ]]; then
+							apache_ssl_cipher_suite+=":"
+						fi
+						apache_ssl_cipher_suite+="${cipher_match}"
+					fi
+				done
+
+				assert equal \
+					"${apache_ssl_cipher_suite}" \
+					"DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA"
+			end
+
+			it "Allows configuration of the SSL/TLS protocols."
+				local apache_ssl_cipher_suite=""
+				local cipher_match=""
+				local protocol=""
+
+				docker_terminate_container \
+					apache-php.pool-1.1.1 \
+				&> /dev/null
+
+				docker run -d \
+					--name apache-php.pool-1.1.1 \
+					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+					--env APACHE_MOD_SSL_ENABLED="true" \
+					--env APACHE_SERVER_NAME="www.app-1.local" \
+					--env APACHE_SSL_CERTIFICATE="${certificate_pem_base64}" \
+					--env APACHE_SSL_CIPHER_SUITE="DHE-RSA-AES128-SHA" \
+					--env APACHE_SSL_PROTOCOL="all -SSLv3 -TLSv1 -TLSv1.1" \
+					jdeathe/centos-ssh-apache-php:latest \
+				&> /dev/null
+
+				container_port_443="$(
+					docker port \
+						apache-php.pool-1.1.1 \
+						443/tcp
+				)"
+				container_port_443=${container_port_443##*:}
+
+				sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+				for protocol in ssl3 tls1 tls1_1 tls1_2; do
+					cipher_match="$(
+						echo -n \
+						| openssl s_client \
+							-${protocol} \
+							-connect 127.0.0.1:${container_port_443} \
+							-CAfile /tmp/www.app-1.local.pem \
+							-nbio \
+							2>&1 \
+						| grep -o "^[ ]*Cipher[ ]*: .*$" \
+						| awk '{ print $3 }'
+					)"
+
+					if [[ -n ${cipher_match} ]]; then
+						if [[ -n ${apache_ssl_cipher_suite} ]]; then
+							apache_ssl_cipher_suite+=":"
+						fi
+						apache_ssl_cipher_suite+="${cipher_match}"
+					fi
+				done
+
+				assert equal \
+					"${apache_ssl_cipher_suite}" \
+					"0000:0000:0000:DHE-RSA-AES128-SHA"
+			end
+		end
+
+		it "Allows configuration of the PHP date.timezone (e.g Europe/London)."
+			local php_date_timezone=""
+
+			docker_terminate_container \
+				apache-php.pool-1.1.1 \
+			&> /dev/null
+
+			docker run -d \
+				--name apache-php.pool-1.1.1 \
+				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
+				--env PHP_OPTIONS_DATE_TIMEZONE="Europe/London" \
+				jdeathe/centos-ssh-apache-php:latest \
+			&> /dev/null
+
+			sleep ${BOOTSTRAP_BACKOFF_TIME}
+
+			php_date_timezone="$(
+				docker exec \
+					apache-php.pool-1.1.1 \
+					php \
+						-r \
+						"printf('%s', ini_get('date.timezone'));"
+			)"
+
+			status_apache_server_status_pattern=${?}
+
+			assert equal \
+				"${php_date_timezone}" \
+				"Europe/London"
+		end
+
+		docker_terminate_container \
+			apache-php.pool-1.1.1 \
+		&> /dev/null
+
+		trap - \
+			INT TERM EXIT
+	end
+end

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## Functional
+
+### Installation
+
+The functional test cases are written in [shpec](https://github.com/rylnd/shpec). 
+
+To run the tests install shpec with the installer.
+
+```
+$ bash -c "$(curl -L https://raw.github.com/rylnd/shpec/master/install.sh)"
+```
+
+### Usage
+
+To manually run the test cases, from the project root:
+
+```
+$ SHPEC_ROOT=test/shpec shpec
+```


### PR DESCRIPTION
Resolves #295 - patch back #287 to centos-6 branch.

_NOTE:_ Some tests needed altering to work with the Apache 2.2.

- The loaded modules differs however `ssl_module` is loaded in Version 2 even when SSL support is not enabled. Have raised an issue about including the version_module since it's required in Version 2.
- Calls to apachectl required `2>&1` adding to suppress the output of "Syntax OK". 
- The debug logging writes a different string identifier; updated pattern.
- The server-status output is limited (probably due to ExtendedStatus being disabled); Updated pattern to `^Scoreboard: [\._SRWKDCLGI]+$`.
- Pattern match for Server MPM needs to be case insensitive; update pattern to `grep -qiE '^Server MPM:[ ]+worker$'`.
- The configuration of the default host used for testing ServerName needed a few changes:
  - Removed the Listen directive.
  - Removed the IsVersion blocks; version_module not loaded.
  - Since NameVirtualHosts is included it needed to be commented out of the VirtualHost configuration that follows it.

