### PR TITLE
CLOSES #293: Adds fix to set the Apache run group.

### DIFF
--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -999,8 +999,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				| awk '{ print $1 }'
 			)"
 
-			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_user}" "runner"
+			assert equal \
+				"${apache_run_user}" \
+				"runner"
 		end
 
 		it "Allows configuration of the run group (i.e. process runner's group)."
@@ -1027,8 +1028,9 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 				| awk '{ print $2 }'
 			)"
 
-			# TODO - ISSUE 293: Setting APACHE_RUN_GROUP ineffective.
-			# assert equal "${apache_run_group}" "runners"
+			assert equal \
+				"${apache_run_group}" \
+				"runners"
 		end
 
 		it "Allows configuration of the ServerName (e.g app-1.local)."

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -823,7 +823,7 @@ fi
 update_user_login "${DEFAULT_SYSTEM_USER}" "${OPTS_APACHE_SYSTEM_USER}"
 update_group_name "${DEFAULT_SYSTEM_USER}" "${OPTS_APACHE_SYSTEM_USER}"
 update_user_login "${DEFAULT_APACHE_USER}" "${OPTS_APACHE_RUN_USER}"
-update_group_name "${DEFAULT_APACHE_USER}" "${OPTS_APACHE_RUN_USER}"
+update_group_name "${DEFAULT_APACHE_USER}" "${OPTS_APACHE_RUN_GROUP}"
 
 # Wait for background processes
 wait ${PIDS[0]}


### PR DESCRIPTION
Resolves #293 

- Set the Apache run group to the group defined in `APACHE_RUN_GROUP`.