### PR TITLE
CLOSES #315: Fixes issue with app package requirement for  `etc/php.d`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Summary of release changes for Version 2.
 
 CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
 
-### 2.0.2 - Unreleased
+### 2.1.0 - Unreleased
 
 - Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
 - Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Summary of release changes for Version 2.
 
 CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
 
+### 2.0.2 - Unreleased
+
+- Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
+- Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.
+
 ### 2.0.1 - 2017-01-24
 
 - Replaces `mv` operations with `cat` to work-around OverlayFS limitations in CentOS-7.

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -398,7 +398,8 @@ function load_httpd_conf_scan_files ()
 	local FILE_PATH
 	local PACKAGE_PATH="${1:-}"
 
-	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+	if [[ -n ${PACKAGE_PATH} ]] \
+		&& [[ -d ${PACKAGE_PATH}/etc/httpd/conf.d ]]; then
 		for FILE_PATH in "${PACKAGE_PATH}"/etc/httpd/conf.d/*.conf; do
 			cat  \
 				"${FILE_PATH}" \
@@ -413,7 +414,8 @@ function load_php_ini_scan_files ()
 	local PACKAGE_PATH="${1:-}"
 	local SCAN_DIRECTORY="/etc/php.d"
 
-	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+	if [[ -n ${PACKAGE_PATH} ]] \
+		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
 		# Replace environment variables to support fcgid php-wrapper
 		for FILE_PATH in "${PACKAGE_PATH}"/etc/php.d/*.ini; do
 			printf -- \


### PR DESCRIPTION
Resolves #315 

- Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
- Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.