### PR TITLE
CLOSES #320: Fixes issue with app package requirement for `etc/php.d`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.8 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 ### 1.9.0 - Unreleased
 
 - Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
+- Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.
 
 ### 1.8.2 - 2017-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.8 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
+### 1.9.0 - Unreleased
+
+- Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
+
 ### 1.8.2 - 2017-01-24
 
 - Replaces `mv` operations with `cat` to work-around OverlayFS limitations in CentOS-7.

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -301,7 +301,8 @@ function load_httpd_conf_scan_files ()
 	local FILE_PATH
 	local PACKAGE_PATH="${1:-}"
 
-	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+	if [[ -n ${PACKAGE_PATH} ]] \
+		&& [[ -d ${PACKAGE_PATH}/etc/httpd/conf.d ]]; then
 		for FILE_PATH in "${PACKAGE_PATH}"/etc/httpd/conf.d/*.conf; do
 			cat  \
 				"${FILE_PATH}" \
@@ -315,7 +316,8 @@ function load_php_ini_scan_files ()
 	local FILE_PATH
 	local PACKAGE_PATH="${1:-}"
 
-	if [[ -n ${PACKAGE_PATH} ]] && [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
+	if [[ -n ${PACKAGE_PATH} ]] \
+		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
 		# Replace environment variables to support fcgid php-wrapper
 		for FILE_PATH in "${PACKAGE_PATH}"/etc/php.d/*.ini; do
 			printf -- \


### PR DESCRIPTION
Resolves #320 

- Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
- Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.