### PR TITLE
CLOSES #316: Adds default Apache modules to `httpd-bootstrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 
 - Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
 - Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.
+- Adds default Apache modules appropriate for Apache 2.4/2.2 in the bootstrap script for the unlikely case where the values in the environment and configuration file defaults are both unset.
 
 ### 2.0.1 - 2017-01-24
 

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -636,18 +636,43 @@ function update_user_login ()
 
 DEFAULT_SYSTEM_USER=app
 DEFAULT_APACHE_USER=app-www
-DEFAULT_APACHE_LOAD_MODULES="
- authz_user_module
- log_config_module
- expires_module
- deflate_module
- headers_module
- setenvif_module
- mime_module
- status_module
- dir_module
- alias_module
-"
+if [[ -f /etc/httpd/conf.modules.d/00-base.conf ]]; then
+	# Default Apache 2.4 DSO Modules
+	DEFAULT_APACHE_LOAD_MODULES="
+	 authz_core_module
+	 authz_user_module
+	 log_config_module
+	 expires_module
+	 deflate_module
+	 filter_module
+	 headers_module
+	 setenvif_module
+	 socache_shmcb_module
+	 mime_module
+	 status_module
+	 dir_module
+	 alias_module
+	 unixd_module
+	 version_module
+	 proxy_module
+	 proxy_fcgi_module
+	"
+else
+	# Default Apache 2.2 DSO Modules
+	DEFAULT_APACHE_LOAD_MODULES="
+	 authz_user_module
+	 log_config_module
+	 expires_module
+	 deflate_module
+	 headers_module
+	 setenvif_module
+	 mime_module
+	 status_module
+	 dir_module
+	 alias_module
+	 version_module
+	"
+fi
 PACKAGE_PATH="${PACKAGE_PATH:-/opt/app}"
 PASSWORD_LENGTH=16
 


### PR DESCRIPTION
Resolves #316 

- Adds default Apache modules appropriate for Apache 2.4/2.2 in the bootstrap script for the unlikely case where the values in the environment and configuration file defaults are both unset.