### PR TITLE
CLOSES #318: Document's prerequisites of SCMI install examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Fixes issue with app specific `httpd` configuration requiring the `etc/php.d` directory to exist.
 - Fixes `shpec` test definition to allow tests to be interruptible + ports back some minor improvements made to the tests for the fcgid version.
 - Adds default Apache modules appropriate for Apache 2.4/2.2 in the bootstrap script for the unlikely case where the values in the environment and configuration file defaults are both unset.
+- Updates `README.md` with details of the SCMI install example's prerequisite step of either pulling or loading the image.
 
 ### 2.0.1 - 2017-01-24
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,15 @@ If your docker host has systemd, fleetd (and optionally etcd) installed then `sc
 
 Since release `centos-6-1.7.2` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
 
-To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
+_NOTE:_ A prerequisite of the following examples is that the image has been pulled (or loaded from the release package).
 
 ```
 $ docker pull jdeathe/centos-ssh-apache-php:2.0.1
+```
+
+To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
+
+```
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \


### PR DESCRIPTION
Resolves #318 

- Updates `README.md` with details of the SCMI install example's prerequisite step of either pulling or loading the image.