### PR TITLE
CLOSES #313: Prevent `ssl_module` being loaded when not required.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Updates `README.md` with details of the SCMI install example's prerequisite step of either pulling or loading the image.
 - Updates package versions for `httpd24u` and `php56u` + define specific versions in the Dockerfile.
 - Fixes issue with `ssl_module` being loaded when `APACHE_MOD_SSL_ENABLED` was set to `false`.
+- Fixes noisy certificate generation output in logs during bootstrap when `APACHE_MOD_SSL_ENABLED` is `true`.
 
 ### 2.0.1 - 2017-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Adds default Apache modules appropriate for Apache 2.4/2.2 in the bootstrap script for the unlikely case where the values in the environment and configuration file defaults are both unset.
 - Updates `README.md` with details of the SCMI install example's prerequisite step of either pulling or loading the image.
 - Updates package versions for `httpd24u` and `php56u` + define specific versions in the Dockerfile.
+- Fixes issue with `ssl_module` being loaded when `APACHE_MOD_SSL_ENABLED` was set to `false`.
 
 ### 2.0.1 - 2017-01-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,22 +101,23 @@ RUN cp -pf \
 # -----------------------------------------------------------------------------
 RUN sed -i \
 	-e 's~^\(LoadModule .*\)$~#\1~g' \
-	-e 's~^#LoadModule mime_module ~LoadModule mime_module ~g' \
-	-e 's~^#LoadModule log_config_module ~LoadModule log_config_module ~g' \
-	-e 's~^#LoadModule setenvif_module ~LoadModule setenvif_module ~g' \
-	-e 's~^#LoadModule status_module ~LoadModule status_module ~g' \
-	-e 's~^#LoadModule authz_host_module ~LoadModule authz_host_module ~g' \
-	-e 's~^#LoadModule dir_module ~LoadModule dir_module ~g' \
-	-e 's~^#LoadModule alias_module ~LoadModule alias_module ~g' \
-	-e 's~^#LoadModule expires_module ~LoadModule expires_module ~g' \
-	-e 's~^#LoadModule deflate_module ~LoadModule deflate_module ~g' \
-	-e 's~^#LoadModule headers_module ~LoadModule headers_module ~g' \
-	-e 's~^#LoadModule alias_module ~LoadModule alias_module ~g' \
-	-e 's~^#LoadModule version_module ~LoadModule version_module ~g' \
+	-e 's~^#\(LoadModule mime_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule log_config_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule setenvif_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule status_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule authz_host_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule dir_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule alias_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule expires_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule deflate_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule headers_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule alias_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule version_module .*\)$~\1~' \
 	/etc/httpd/conf.modules.d/00-base.conf \
 	/etc/httpd/conf.modules.d/00-dav.conf \
 	/etc/httpd/conf.modules.d/00-lua.conf \
-	/etc/httpd/conf.modules.d/00-proxy.conf
+	/etc/httpd/conf.modules.d/00-proxy.conf \
+	/etc/httpd/conf.modules.d/00-ssl.conf
 
 # -----------------------------------------------------------------------------
 # Disable SSL + the default SSL Virtual Host

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -449,7 +449,7 @@ describe "jdeathe/centos-ssh-apache-php:latest"
 
 			it "Loads all the required Apache modules."
 				readonly required_apache_modules="authz_core_module authz_user_module log_config_module expires_module deflate_module filter_module headers_module setenvif_module socache_shmcb_module mime_module status_module dir_module alias_module unixd_module version_module proxy_module proxy_fcgi_module"
-				readonly other_required_apache_modules="core_module so_module http_module authz_host_module mpm_prefork_module ssl_module cgi_module"
+				readonly other_required_apache_modules="core_module so_module http_module authz_host_module mpm_prefork_module cgi_module"
 				local status_apache_modules_loaded=0
 
 				for module in ${required_apache_modules}; do

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -831,11 +831,23 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off \
 			> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
 	fi
+
+	if [[ -f /etc/httpd/conf.modules.d/00-ssl.conf ]]; then
+		sed -i \
+			-e 's~^#\(LoadModule ssl_module .*\)$~\1~' \
+			/etc/httpd/conf.modules.d/00-ssl.conf
+	fi
 else
 	> /etc/httpd/conf.d/ssl.conf
 
 	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf ]]; then
 		> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
+	fi
+
+	if [[ -f /etc/httpd/conf.modules.d/00-ssl.conf ]]; then
+		sed -i \
+			-e 's~^\(LoadModule ssl_module .*\)$~#\1~' \
+			/etc/httpd/conf.modules.d/00-ssl.conf
 	fi
 fi
 

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -718,6 +718,7 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
 		'LOCALITY' \
 		'ORGANIZATION' \
 		"${OPTS_APACHE_SERVER_NAME}" \
+		1&> /dev/null \
 		&
 
 	PIDS[2]=${!}


### PR DESCRIPTION
Resolves #313

- Fixes issue with `ssl_module` being loaded when `APACHE_MOD_SSL_ENABLED` was set to `false`.
- Fixes noisy certificate generation output in logs during bootstrap when `APACHE_MOD_SSL_ENABLED` is `true`.