### PR TITLE
CLOSES #332: Fixes noisy certificate generation output in logs during bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-6 6.8 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Adds default Apache modules appropriate for Apache 2.4/2.2 in the bootstrap script for the unlikely case where the values in the environment and configuration file defaults are both unset.
 - Updates `README.md` with details of the SCMI install example's prerequisite step of either pulling or loading the image.
 - Updates `httpd` and `mod_ssl` packages.
+- Fixes noisy certificate generation output in logs during bootstrap when `APACHE_MOD_SSL_ENABLED` is `true`.
 
 ### 1.8.2 - 2017-01-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,17 +84,17 @@ RUN sed -i \
 # -----------------------------------------------------------------------------
 RUN sed -i \
 	-e 's~^\(LoadModule .*\)$~#\1~g' \
-	-e 's~^#LoadModule mime_module ~LoadModule mime_module ~g' \
-	-e 's~^#LoadModule log_config_module ~LoadModule log_config_module ~g' \
-	-e 's~^#LoadModule setenvif_module ~LoadModule setenvif_module ~g' \
-	-e 's~^#LoadModule status_module ~LoadModule status_module ~g' \
-	-e 's~^#LoadModule authz_host_module ~LoadModule authz_host_module ~g' \
-	-e 's~^#LoadModule dir_module ~LoadModule dir_module ~g' \
-	-e 's~^#LoadModule alias_module ~LoadModule alias_module ~g' \
-	-e 's~^#LoadModule expires_module ~LoadModule expires_module ~g' \
-	-e 's~^#LoadModule deflate_module ~LoadModule deflate_module ~g' \
-	-e 's~^#LoadModule headers_module ~LoadModule headers_module ~g' \
-	-e 's~^#LoadModule alias_module ~LoadModule alias_module ~g' \
+	-e 's~^#\(LoadModule mime_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule log_config_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule setenvif_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule status_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule authz_host_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule dir_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule alias_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule expires_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule deflate_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule headers_module .*\)$~\1~' \
+	-e 's~^#\(LoadModule alias_module .*\)$~\1~' \
 	-e 's~^#\(LoadModule version_module .*\)$~\1\n#LoadModule reqtimeout_module modules/mod_reqtimeout.so~g' \
 	/etc/httpd/conf/httpd.conf
 

--- a/usr/sbin/httpd-bootstrap
+++ b/usr/sbin/httpd-bootstrap
@@ -564,6 +564,7 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
 		'LOCALITY' \
 		'ORGANIZATION' \
 		"${OPTS_APACHE_SERVER_NAME}" \
+		1&> /dev/null \
 		&
 
 	PIDS[2]=${!}
@@ -697,11 +698,23 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 			/etc/services-config/httpd/conf.d/10-ssl-vhost.conf.off \
 			> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
 	fi
+
+	if [[ -f /etc/httpd/conf.modules.d/00-ssl.conf ]]; then
+		sed -i \
+			-e 's~^#\(LoadModule ssl_module .*\)$~\1~' \
+			/etc/httpd/conf.modules.d/00-ssl.conf
+	fi
 else
 	> /etc/httpd/conf.d/ssl.conf
 
 	if [[ -f /etc/services-config/httpd/conf.d/10-ssl-vhost.conf ]]; then
 		> /etc/services-config/httpd/conf.d/10-ssl-vhost.conf
+	fi
+
+	if [[ -f /etc/httpd/conf.modules.d/00-ssl.conf ]]; then
+		sed -i \
+			-e 's~^\(LoadModule ssl_module .*\)$~#\1~' \
+			/etc/httpd/conf.modules.d/00-ssl.conf
 	fi
 fi
 


### PR DESCRIPTION
Resolves #332

- Fixes noisy certificate generation output in logs during bootstrap when `APACHE_MOD_SSL_ENABLED` is `true`.