### PR TITLE
CLOSES #281: Fixes APACHE_HEADER_X_SERVICE_UID populating with unexpected hostname.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Changes `APACHE_SERVER_ALIAS` to a default empty value for `Makefile`, `scmi` and `systemd` templates which is the existing `Dockerfile` default.
 - Changes description of app to include "PHP-FPM (FastCGI)" instead of "PHP (PHP-FPM)".
 - Changes default `APACHE_SERVER_NAME` to unset and use the container's hostname for the Apache ServerName.
+- Fixes `scmi` install/uninstall examples and Dockerfile `LABEL` install/uninstall templates to prevent the `X-Service-UID` header being populated with the hostname of the ephemeral container used to run `scmi`.
 
 ### 2.0.1 - 2017-01-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -322,6 +322,8 @@ LABEL \
 --rm \
 --privileged \
 --volume /:/media/root \
+--env BASH_ENV="" \
+--env ENV="" \
 jdeathe/centos-ssh-apache-php:${RELEASE_VERSION} \
 /usr/sbin/scmi install \
 --chroot=/media/root \
@@ -331,6 +333,8 @@ jdeathe/centos-ssh-apache-php:${RELEASE_VERSION} \
 --rm \
 --privileged \
 --volume /:/media/root \
+--env BASH_ENV="" \
+--env ENV="" \
 jdeathe/centos-ssh-apache-php:${RELEASE_VERSION} \
 /usr/sbin/scmi uninstall \
 --chroot=/media/root \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
+  --env BASH_ENV="" \
+  --env ENV="" \
   jdeathe/centos-ssh-apache-php:2.0.1 \
   /usr/sbin/scmi install \
     --chroot=/media/root \
@@ -111,6 +113,8 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
+  --env BASH_ENV="" \
+  --env ENV="" \
   jdeathe/centos-ssh-apache-php:2.0.1 \
   /usr/sbin/scmi uninstall \
     --chroot=/media/root \
@@ -127,6 +131,8 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
+  --env BASH_ENV="" \
+  --env ENV="" \
   jdeathe/centos-ssh-apache-php:2.0.1 \
   /usr/sbin/scmi install \
     --chroot=/media/root \


### PR DESCRIPTION
Resolves #281

- Fixes issue with `X-Service-UID` header being populated with an incorrect value for installations using `scmi` (or atomic install) from an ephemeral container.