### PR TITLE
CLOSES #292: Removes unrequired environment variable re-mappings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Changes default `APACHE_SERVER_NAME` to unset and use the container's hostname for the Apache ServerName.
 - Fixes `scmi` install/uninstall examples and Dockerfile `LABEL` install/uninstall templates to prevent the `X-Service-UID` header being populated with the hostname of the ephemeral container used to run `scmi`.
 - Adds feature to allow both `APACHE_SERVER_NAME` and `APACHE_SERVER_ALIAS` to contain the `{{HOSTNAME}}` placeholder which is replaced on startup with the container's hostname.
+- Removes environment variable re-mappings that are no longer in use: `APP_HOME_DIR`, `APACHE_SUEXEC_USER_GROUP`, `DATE_TIMEZONE`, `SERVICE_USER`, `SUEXECUSERGROUP`, `SERVICE_UID`.
 
 ### 2.0.1 - 2017-01-24
 

--- a/etc/services-config/supervisor/supervisord.d/httpd-bootstrap.conf
+++ b/etc/services-config/supervisor/supervisord.d/httpd-bootstrap.conf
@@ -7,4 +7,3 @@ autorestart = false
 redirect_stderr = true
 stdout_logfile = /var/log/httpd/error_log
 stdout_events_enabled = true
-environment = APP_HOME_DIR="%(ENV_APACHE_CONTENT_ROOT)s",APACHE_SUEXEC_USER_GROUP="false",DATE_TIMEZONE="%(ENV_PHP_OPTIONS_DATE_TIMEZONE)s",SERVICE_USER="%(ENV_APACHE_SYSTEM_USER)s",SUEXECUSERGROUP="false",SERVICE_UID="%(ENV_APACHE_HEADER_X_SERVICE_UID)s"

--- a/etc/services-config/supervisor/supervisord.d/httpd-wrapper.conf
+++ b/etc/services-config/supervisor/supervisord.d/httpd-wrapper.conf
@@ -6,4 +6,3 @@ autorestart = true
 redirect_stderr = true
 stdout_logfile = /var/log/httpd/error_log
 stdout_events_enabled = true
-environment = APP_HOME_DIR="%(ENV_APACHE_CONTENT_ROOT)s",APACHE_SUEXEC_USER_GROUP="false",DATE_TIMEZONE="%(ENV_PHP_OPTIONS_DATE_TIMEZONE)s",SERVICE_USER="%(ENV_APACHE_SYSTEM_USER)s",SUEXECUSERGROUP="false",SERVICE_UID="%(ENV_APACHE_HEADER_X_SERVICE_UID)s"


### PR DESCRIPTION
Resolves #292 

- Removes environment variable re-mappings that are no longer in use: `APP_HOME_DIR`, `APACHE_SUEXEC_USER_GROUP`, `DATE_TIMEZONE`, `SERVICE_USER`, `SUEXECUSERGROUP`, `SERVICE_UID`.

