### PR TITLE
ISSUE 356: Expands on the use of watch to monitor server-status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Adds feature to allow both `APACHE_SERVER_NAME` and `APACHE_SERVER_ALIAS` to contain the `{{HOSTNAME}}` placeholder which is replaced on startup with the container's hostname.
 - Removes environment variable re-mappings that are no longer in use: `APP_HOME_DIR`, `APACHE_SUEXEC_USER_GROUP`, `DATE_TIMEZONE`, `SERVICE_USER`, `SUEXECUSERGROUP`, `SERVICE_UID`.
 - Changes Apache configuration so that `NameVirtualHost` and `Listen` are separated out from `VirtualHost`.
+- Adds further information on the use of `watch` to monitor `server-status`.
 
 ### 2.0.1 - 2017-01-24
 

--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ The variable `APACHE_EXTENDED_STATUS_ENABLED` allows you to turn ExtendedStatus 
 ...
 ```
 
-You can view the output from Apache server-status either using the elinks browser from onboard the container or by using `watch` and `curl` to monitor status over time - the following command shows the server-status updated at a 1 second interval.
+You can view the output from Apache server-status either using the elinks browser from onboard the container or by using `watch` and `curl` to monitor status over time. The following command shows the server-status updated at a 1 second interval given an `APACHE_SERVER_NAME` or `APACHE_SERVER_ALIAS` of "app-1.local".
 
 ```
 $ docker exec -it apache-php.pool-1.1.1 \
   env TERM=xterm \
   watch -n 1 \
-  -d "curl -s http://app-1/server-status?auto"
+  -d "curl -sH 'Host: app-1.local' http://127.0.0.1/server-status?auto"
 ```
 
 ##### APACHE_HEADER_X_SERVICE_UID


### PR DESCRIPTION
Resolves #356 

- Adds further information on the use of `watch` to monitor `server-status`.