### PR TITLE
CLOSES #376: Replaces deprecated Dockerfile MAINTAINER with a LABEL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 
 - Adds updated `httpd24u` and `php56u` packages to 2.4.25-4 and 5.6.30-2.
 - Adds improvement to VirtualHost pattern match used to disable default SSL.
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 
 ### 2.1.1 - 2017-03-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 # =============================================================================
 FROM jdeathe/centos-ssh:1.7.6
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"
 ARG PACKAGE_PATH="/opt/${PACKAGE_NAME}"
@@ -319,6 +317,7 @@ ENV APACHE_CUSTOM_LOG_FORMAT="combined" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="2.1.1"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="docker run \
 --rm \
 --privileged \


### PR DESCRIPTION
Resolves #376 

- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.