### PR TITLE
CLOSES #375: Replaces deprecated Dockerfile MAINTAINER with a LABEL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.8 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
 - Adds updated packages `httpd` (including `mod_ssl`) and `php` to 2.2.15-59 and 5.3.3-49.
 - Adds improvement to VirtualHost pattern match used to disable default SSL.
+- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 
 ### 1.9.1 - 2017-03-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@
 # =============================================================================
 FROM jdeathe/centos-ssh:1.7.6
 
-MAINTAINER James Deathe <james.deathe@gmail.com>
-
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"
 ARG PACKAGE_PATH="/opt/${PACKAGE_NAME}"
@@ -271,6 +269,7 @@ ENV APACHE_CUSTOM_LOG_FORMAT="combined" \
 # -----------------------------------------------------------------------------
 ARG RELEASE_VERSION="1.9.1"
 LABEL \
+	maintainer="James Deathe <james.deathe@gmail.com>" \
 	install="docker run \
 --rm \
 --privileged \


### PR DESCRIPTION
Resolves #375 

- Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.