### PR TITLE
CLOSES #401: Updates httpd24u and php56u-pecl-memcached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ CentOS-6 6.8 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 
 ### 2.2.0 - Unreleased
 
-- Adds updated `httpd24u` and `php56u` packages to 2.4.25-4 and 5.6.30-2.
+- Adds updated `httpd24u` and `php56u` packages to 2.4.26-1 and 5.6.30-2.
 - Adds improvement to VirtualHost pattern match used to disable default SSL.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@ ARG PACKAGE_RELEASE_VERSION="0.4.0"
 RUN rpm --rebuilddb \
 	&& yum --setopt=tsflags=nodocs -y install \
 		elinks-0.12-0.21.pre5.el6_3 \
-		httpd24u-2.4.25-4.ius.centos6 \
-		httpd24u-tools-2.4.25-4.ius.centos6 \
-		httpd24u-mod_ssl-2.4.25-4.ius.centos6 \
+		httpd24u-2.4.26-1.ius.centos6 \
+		httpd24u-tools-2.4.26-1.ius.centos6 \
+		httpd24u-mod_ssl-2.4.26-1.ius.centos6 \
 		php56u-fpm-5.6.30-2.ius.centos6 \
 		php56u-fpm-httpd-5.6.30-2.ius.centos6 \
 		php56u-cli-5.6.30-2.ius.centos6 \
 		php56u-opcache-5.6.30-2.ius.centos6 \
-		php56u-pecl-memcached-5.6.30-2.ius.centos6 \
+		php56u-pecl-memcached-2.2.0-6.ius.centos6 \
 	&& yum versionlock add \
 		elinks \
 		httpd24u* \


### PR DESCRIPTION
Resolves #401 

- Updates `httpd24u` and `php56u-pecl-memcached` packages to prevent image build failure.