### PR TITLE
CLOSES #403: Removes healthcheck from functional tests of access log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Adds use of `/var/lock/subsys/` (subsystem lock directory) for bootstrap lock files.
 - Adds test case output with improved readability.
 - Adds a healthcheck.
+- Removes healthcheck from functional tests of access log to prevent intermittent failures.
 
 ### 2.1.1 - 2017-03-12
 

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -246,7 +246,7 @@ function main ()
 
 	# httpd-wrapper
 	if ! ps axo command \
-		| grep -qE '^/usr/sbin/httpd '
+		| grep -qE '^/usr/sbin/httpd(\.worker)? '
 	then
 		exit 1
 	fi

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -202,6 +202,7 @@ ${other_required_apache_modules}
 		describe "Runs named container"
 			docker run \
 				--detach \
+				--no-healthcheck \
 				--name apache-php.pool-1.1.1 \
 				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 				jdeathe/centos-ssh-apache-php:latest \
@@ -635,6 +636,7 @@ function test_custom_configuration ()
 
 				docker run \
 					--detach \
+					--no-healthcheck \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_FORMAT="common" \
@@ -679,6 +681,7 @@ function test_custom_configuration ()
 
 				docker run \
 					--detach \
+					--no-healthcheck \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_LOCATION="var/log/access.log" \
@@ -718,6 +721,7 @@ function test_custom_configuration ()
 
 				docker run \
 					--detach \
+					--no-healthcheck \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_LOCATION="/var/log/httpd/access.log" \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -545,7 +545,7 @@ ${other_required_apache_modules}
 					bash -c "apachectl -M 2>&1 \
 						| sed -r \
 							-e '/Loaded Modules:/d' \
-							-e 's~^ *([a-z_]*).*~\1~g'"
+							-e 's~^ *([0-9a-z_]*).*~\1~g'"
 			)"
 
 			it "Has all required."

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -200,7 +200,8 @@ ${other_required_apache_modules}
 		&> /dev/null
 
 		describe "Runs named container"
-			docker run -d \
+			docker run \
+				--detach \
 				--name apache-php.pool-1.1.1 \
 				--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 				jdeathe/centos-ssh-apache-php:latest \
@@ -228,7 +229,7 @@ ${other_required_apache_modules}
 
 		if ! __is_container_ready \
 			apache-php.pool-1.1.1 \
-			"/usr/sbin/httpd "; then
+			"/usr/sbin/httpd(\.worker)? "; then
 			exit 1
 		fi
 
@@ -543,7 +544,7 @@ ${other_required_apache_modules}
 					bash -c "apachectl -M 2>&1 \
 						| sed -r \
 							-e '/Loaded Modules:/d' \
-							-e 's~^ *([a-z_]+).*$~\1~g'"
+							-e 's~^ *([a-z_]*).*~\1~g'"
 			)"
 
 			it "Has all required."
@@ -632,7 +633,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_FORMAT="common" \
@@ -642,7 +644,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -675,7 +677,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_LOCATION="var/log/access.log" \
@@ -685,7 +688,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -713,7 +716,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_CUSTOM_LOG_LOCATION="/var/log/httpd/access.log" \
@@ -723,7 +727,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -753,7 +757,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_ERROR_LOG_LOCATION="var/log/error.log" \
@@ -763,7 +768,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -788,7 +793,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_ERROR_LOG_LOCATION="/var/log/httpd/error.log" \
@@ -797,7 +803,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -822,7 +828,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_ERROR_LOG_LEVEL="debug" \
@@ -832,7 +839,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -846,7 +853,7 @@ function test_custom_configuration ()
 					tail -n 1 \
 					/var/www/app/var/log/apache_error_log \
 				| grep -qE \
-					' \[.+:debug\] ' \
+					' \[(.+:)?debug\] ' \
 				&> /dev/null
 
 				assert equal \
@@ -861,7 +868,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_EXTENDED_STATUS_ENABLED="true" \
@@ -871,7 +879,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -925,7 +933,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_HEADER_X_SERVICE_UID="host-name@1.2" \
@@ -935,7 +944,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -958,7 +967,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_HEADER_X_SERVICE_UID="{{HOSTNAME}}:${DOCKER_PORT_MAP_TCP_80}" \
@@ -968,7 +978,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -993,7 +1003,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--env APACHE_LOAD_MODULES="authz_core_module authz_user_module log_config_module expires_module deflate_module filter_module headers_module setenvif_module socache_shmcb_module mime_module status_module dir_module alias_module unixd_module version_module proxy_module proxy_fcgi_module rewrite_module" \
 					jdeathe/centos-ssh-apache-php:latest \
@@ -1001,7 +1012,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1021,7 +1032,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--env APACHE_MPM="event" \
 					--hostname app-1.local \
@@ -1030,7 +1042,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1050,7 +1062,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_OPERATING_MODE="development" \
@@ -1060,7 +1073,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1085,7 +1098,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--env APACHE_SYSTEM_USER="app-user" \
 					jdeathe/centos-ssh-apache-php:latest \
@@ -1093,7 +1107,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1115,7 +1129,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--env APACHE_RUN_USER="runner" \
 					jdeathe/centos-ssh-apache-php:latest \
@@ -1123,7 +1138,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1146,7 +1161,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--env APACHE_RUN_GROUP="runners" \
 					jdeathe/centos-ssh-apache-php:latest \
@@ -1154,7 +1170,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1179,7 +1195,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_SERVER_NAME="app-1.local" \
@@ -1213,7 +1230,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1262,7 +1279,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--hostname php-hello-world \
@@ -1295,7 +1313,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1328,7 +1346,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--hostname php-hello-world \
@@ -1362,7 +1381,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1397,7 +1416,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--hostname php-hello-world \
@@ -1432,7 +1452,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1467,7 +1487,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_PUBLIC_DIRECTORY="web" \
@@ -1487,7 +1508,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1509,7 +1530,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env APACHE_SERVER_NAME="app-1.local" \
@@ -1557,7 +1579,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1579,7 +1601,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
 					--env APACHE_MOD_SSL_ENABLED="true" \
@@ -1595,7 +1618,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1645,7 +1668,8 @@ function test_custom_configuration ()
 					fi
 				fi
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
 					--env APACHE_MOD_SSL_ENABLED="true" \
@@ -1662,7 +1686,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1694,7 +1718,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
 					--env APACHE_MOD_SSL_ENABLED="true" \
@@ -1712,7 +1737,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1748,7 +1773,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
 					--env APACHE_MOD_SSL_ENABLED="true" \
@@ -1767,7 +1793,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 
@@ -1805,7 +1831,8 @@ function test_custom_configuration ()
 					apache-php.pool-1.1.1 \
 				&> /dev/null
 
-				docker run -d \
+				docker run \
+					--detach \
 					--name apache-php.pool-1.1.1 \
 					--publish ${DOCKER_PORT_MAP_TCP_80}:80 \
 					--env PHP_OPTIONS_DATE_TIMEZONE="Europe/London" \
@@ -1814,7 +1841,7 @@ function test_custom_configuration ()
 
 				if ! __is_container_ready \
 					apache-php.pool-1.1.1 \
-					"/usr/sbin/httpd "; then
+					"/usr/sbin/httpd(\.worker)? "; then
 					exit 1
 				fi
 


### PR DESCRIPTION
Resolves #403: 

- Removes healthcheck from functional tests of access log.
- Changes healthcheck binary test to check for both `httpd` and `httpd.worker` to simplify porting back to the centos-6 branch.