### PR TITLE
CLOSES #395: Adds performance related PHP configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Adds simplified port incrementation handling to systemd unit and make consistent with SCMI.
 - Adds configuration include directory (`conf.virtualhost.d/*.conf`) for VirtualHost partials.
 - Adds configuration for setting RewriteEngine on if the module is loaded.
+- Adds PHP configuration change; ACP opcache is enabled for the CLI.
+- Adds PHP configuration change; File changes will not invalidate APC opcache.
+- Adds PHP configuration change; Disables APC file update protection.
+- Adds PHP configuration change; Increased size and TTL of realpath_cache.
 
 ### 1.9.1 - 2017-03-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,12 +131,28 @@ RUN sed \
 		/etc/php.ini \
 		> /etc/php.d/00-php.ini.default \
 	&& sed \
-		-e 's~^;user_ini.filename =$~user_ini.filename =~g' \
-		-e 's~^;cgi.fix_pathinfo=1$~cgi.fix_pathinfo=1~g' \
-		-e 's~^;date.timezone =$~date.timezone = UTC~g' \
-		-e 's~^expose_php = On$~expose_php = Off~g' \
+		-e 's~^; .*$~~' \
+		-e 's~^;*$~~' \
+		-e '/^$/d' \
+		-e 's~^\[~\n\[~g' \
+		/etc/php.d/apc.ini \
+		> /etc/php.d/apc.ini.default \
+	&& sed \
+		-e 's~^;\(user_ini.filename =\)$~\1~g' \
+		-e 's~^;\(cgi.fix_pathinfo=1\)$~\1~g' \
+		-e 's~^;\(date.timezone =\)$~\1 UTC~g' \
+		-e 's~^\(expose_php = \)On$~\1Off~g' \
+		-e 's~^;\(realpath_cache_size = \).*$~\14096k~' \
+		-e 's~^;\(realpath_cache_ttl = \).*$~\1600~' \
 		/etc/php.d/00-php.ini.default \
-		> /etc/php.d/00-php.ini
+		> /etc/php.d/00-php.ini \
+	&& sed \
+		-e 's~^\(apc.stat=\).*$~\10~g' \
+		-e 's~^\(apc.shm_size=\).*$~\1128M~g' \
+		-e 's~^\(apc.enable_cli=\).*$~\11~g' \
+		-e 's~^\(apc.file_update_protection=\).*$~\10~g' \
+		/etc/php.d/apc.ini.default \
+		> /etc/php.d/apc.ini
 
 # -----------------------------------------------------------------------------
 # APC op-code cache stats

--- a/src/etc/services-config/php/php.d/apc.ini
+++ b/src/etc/services-config/php/php.d/apc.ini
@@ -1,0 +1,32 @@
+extension = apc.so
+apc.enabled=1
+apc.shm_segments=1
+apc.shm_size=128M
+apc.num_files_hint=1024
+apc.user_entries_hint=4096
+apc.ttl=7200
+apc.use_request_time=1
+apc.user_ttl=7200
+apc.gc_ttl=3600
+apc.cache_by_default=1
+apc.filters
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+apc.file_update_protection=2
+apc.enable_cli=1
+apc.max_file_size=1M
+apc.stat=0
+apc.stat_ctime=0
+apc.canonicalize=0
+apc.write_lock=1
+apc.report_autofilter=0
+apc.rfc1867=0
+apc.rfc1867_prefix =upload_
+apc.rfc1867_name=APC_UPLOAD_PROGRESS
+apc.rfc1867_freq=0
+apc.rfc1867_ttl=3600
+apc.include_once_override=0
+apc.lazy_classes=0
+apc.lazy_functions=0
+apc.coredump_unmap=0
+apc.file_md5=0
+apc.preload_path

--- a/src/etc/services-config/php/php.d/apc.ini.default
+++ b/src/etc/services-config/php/php.d/apc.ini.default
@@ -1,0 +1,32 @@
+extension = apc.so
+apc.enabled=1
+apc.shm_segments=1
+apc.shm_size=64M
+apc.num_files_hint=1024
+apc.user_entries_hint=4096
+apc.ttl=7200
+apc.use_request_time=1
+apc.user_ttl=7200
+apc.gc_ttl=3600
+apc.cache_by_default=1
+apc.filters
+apc.mmap_file_mask=/tmp/apc.XXXXXX
+apc.file_update_protection=2
+apc.enable_cli=0
+apc.max_file_size=1M
+apc.stat=1
+apc.stat_ctime=0
+apc.canonicalize=0
+apc.write_lock=1
+apc.report_autofilter=0
+apc.rfc1867=0
+apc.rfc1867_prefix =upload_
+apc.rfc1867_name=APC_UPLOAD_PROGRESS
+apc.rfc1867_freq=0
+apc.rfc1867_ttl=3600
+apc.include_once_override=0
+apc.lazy_classes=0
+apc.lazy_functions=0
+apc.coredump_unmap=0
+apc.file_md5=0
+apc.preload_path


### PR DESCRIPTION
Resolves #395 

- Adds PHP configuration change; ACP opcache is enabled for the CLI.
- Adds PHP configuration change; File changes will not invalidate APC opcache.
- Adds PHP configuration change; Disables APC file update protection.
- Adds PHP configuration change; Increased size and TTL of realpath_cache.