### PR TITLE
CLOSES #418: Adds updated httpd24u packages to 2.4.27-1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 
 ### 2.2.0 - 2017-07-13
 
-- Adds updated `httpd24u` and `php56u` packages to 2.4.26-1 and 5.6.30-2.
+- Adds updated `httpd24u` and `php56u` packages to 2.4.27-1 and 5.6.30-2.
 - Adds improvement to VirtualHost pattern match used to disable default SSL.
 - Replaces deprecated Dockerfile `MAINTAINER` with a `LABEL`.
 - Update source image to [1.8.1 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.1).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ARG PACKAGE_RELEASE_VERSION="0.4.0"
 RUN rpm --rebuilddb \
 	&& yum --setopt=tsflags=nodocs -y install \
 		elinks-0.12-0.21.pre5.el6_3 \
-		httpd24u-2.4.26-1.ius.centos6 \
-		httpd24u-tools-2.4.26-1.ius.centos6 \
-		httpd24u-mod_ssl-2.4.26-1.ius.centos6 \
+		httpd24u-2.4.27-1.ius.centos6 \
+		httpd24u-tools-2.4.27-1.ius.centos6 \
+		httpd24u-mod_ssl-2.4.27-1.ius.centos6 \
 		php56u-fpm-5.6.30-2.ius.centos6 \
 		php56u-fpm-httpd-5.6.30-2.ius.centos6 \
 		php56u-cli-5.6.30-2.ius.centos6 \


### PR DESCRIPTION
Resolves #418 

- Adds updated `httpd24u` and `php56u` packages to 2.4.27-1 and 5.6.30-2.