### PR TITLE
CLOSES #432: Fixes bootstrap lockfile name to match the healthcheck.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 ### 2.2.1 - Unreleased
 
 - Updates `php56u` packages to 5.6.31-1.
+- Fixes bootstrap lockfile name to match the one expected by the healthcheck.
 
 ### 2.2.0 - 2017-07-13
 

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Create lock file
-touch /var/lock/subsys/httpd-bootstrap.lock
+touch /var/lock/subsys/httpd-bootstrap
 
 TIMER_START="$(
 	date +%s.%N
@@ -957,6 +957,6 @@ cat <<-EOT
 EOT
 
 # Release lock file
-rm -f /var/lock/subsys/httpd-bootstrap.lock
+rm -f /var/lock/subsys/httpd-bootstrap
 
 exit 0

--- a/src/usr/sbin/httpd-wrapper
+++ b/src/usr/sbin/httpd-wrapper
@@ -26,7 +26,7 @@ readonly NICENESS="${APACHE_NICENESS:-10}"
 
 while true; do
 	sleep 0.1
-	[[ -e /var/lock/subsys/httpd-bootstrap.lock ]] || break
+	[[ -e /var/lock/subsys/httpd-bootstrap ]] || break
 done
 
 exec ${NICE} \

--- a/src/usr/sbin/php-fpm-wrapper
+++ b/src/usr/sbin/php-fpm-wrapper
@@ -25,7 +25,7 @@ setup_php_fpm_pool
 
 while true; do
 	sleep 0.1
-	[[ -e /var/lock/subsys/httpd-bootstrap.lock ]] || break
+	[[ -e /var/lock/subsys/httpd-bootstrap ]] || break
 done
 
 exec ${NICE} \


### PR DESCRIPTION
Resolves #432 

- Fixes bootstrap lockfile name to match the one expected by the healthcheck.