### PR TITLE
CLOSES #433: Patches back #432.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
+### 1.10.1 - Unreleased
+
+- Fixes bootstrap lockfile name to match the one expected by the healthcheck.
+
 ### 1.10.0 - 2017-07-13
 
 - Adds updated packages `httpd` (including `mod_ssl`) and `php` to 2.2.15-59 and 5.3.3-49.

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Create lock file
-touch /var/lock/subsys/httpd-bootstrap.lock
+touch /var/lock/subsys/httpd-bootstrap
 
 TIMER_START="$(
 	date +%s.%N
@@ -823,6 +823,6 @@ cat <<-EOT
 EOT
 
 # Release lock file
-rm -f /var/lock/subsys/httpd-bootstrap.lock
+rm -f /var/lock/subsys/httpd-bootstrap
 
 exit 0

--- a/src/usr/sbin/httpd-wrapper
+++ b/src/usr/sbin/httpd-wrapper
@@ -26,7 +26,7 @@ readonly NICENESS="${APACHE_NICENESS:-10}"
 
 while true; do
 	sleep 0.1
-	[[ -e /var/lock/subsys/httpd-bootstrap.lock ]] || break
+	[[ -e /var/lock/subsys/httpd-bootstrap ]] || break
 done
 
 exec ${NICE} \


### PR DESCRIPTION
Resolves #433: Patches back #432.

- Fixes bootstrap lockfile name to match the one expected by the healthcheck.