### PR TITLE
CLOSES #458: Updates to upstream source release 1.8.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Adds `APACHE_AUTOSTART_PHP_FPM_WRAPPER` to optionally disable PHP-FPM process startup.
 - Adds `PHP_OPTIONS_SESSION_SAVE_HANDLER` to allow for an external session store.
 - Adds `PHP_OPTIONS_SESSION_SAVE_PATH` to allow for an external session store.
+- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).
 
 ### 2.2.0 - 2017-07-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.1
+FROM jdeathe/centos-ssh:1.8.2
 
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -239,7 +239,9 @@ ${other_required_apache_modules}
 	local status=0
 
 	describe "Basic Apache PHP operations"
-		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; exit 1" \
+		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; \
+		__destroy; \
+		exit 1" \
 			INT TERM EXIT
 
 		__terminate_container \
@@ -679,7 +681,9 @@ function test_custom_configuration ()
 	local protocol=""
 
 	describe "Customised Apache PHP configuration"
-		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; exit 1" \
+		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; \
+			__destroy; \
+			exit 1" \
 			INT TERM EXIT
 
 		describe "Access log"


### PR DESCRIPTION
Resolves #458 

- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).