### PR TITLE
CLOSES #460: Patches back #458.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Adds `APACHE_AUTOSTART_HTTPD_WRAPPER` to optionally disable httpd process startup.
 - Adds `PHP_OPTIONS_SESSION_SAVE_HANDLER` to allow for an external session store.
 - Adds `PHP_OPTIONS_SESSION_SAVE_PATH` to allow for an external session store.
+- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).
 
 ### 1.10.0 - 2017-07-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.1
+FROM jdeathe/centos-ssh:1.8.2
 
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -227,7 +227,9 @@ ${other_required_apache_modules}
 	local status=0
 
 	describe "Basic Apache PHP operations"
-		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; exit 1" \
+		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; \
+		__destroy; \
+		exit 1" \
 			INT TERM EXIT
 
 		__terminate_container \
@@ -667,7 +669,9 @@ function test_custom_configuration ()
 	local protocol=""
 
 	describe "Customised Apache PHP configuration"
-		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; exit 1" \
+		trap "__terminate_container apache-php.pool-1.1.1 &> /dev/null; \
+			__destroy; \
+			exit 1" \
 			INT TERM EXIT
 
 		describe "Access log"


### PR DESCRIPTION
Resolves #460: Patches back #458.

- Updates source image to [1.8.2 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.2).