### PR TITLE
CLOSES #485: Adds correction to apache modules in usage instructions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Updates `php56u` packages to 5.6.33-1.
 - Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).
 - Updates php-hello-world to [0.6.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.6.0).
+- Adds correction to usage instructions for `APACHE_LOAD_MODULES`; the required modules were incorrect in the example.
 
 ### 2.2.2 - 2017-12-25
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The variable `APACHE_LOAD_MODULES` defines all Apache modules to be loaded from 
 
 ```
 ...
-  --env "APACHE_LOAD_MODULES=authz_user_module log_config_module expires_module deflate_module headers_module setenvif_module mime_module status_module dir_module alias_module rewrite_module"
+  --env "APACHE_LOAD_MODULES=authz_core_module authz_user_module log_config_module expires_module deflate_module filter_module headers_module setenvif_module socache_shmcb_module mime_module status_module dir_module alias_module unixd_module version_module proxy_module proxy_fcgi_module rewrite_module"
 ...
 ```
 


### PR DESCRIPTION
Resolves #485 

- Adds correction to usage instructions for `APACHE_LOAD_MODULES`; the required modules were incorrect in the example.