### PR TITLE
CLOSES #501: Deprecates us of fleet --manager option in scmi installer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Updates php-hello-world to [0.6.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.6.0).
 - Adds correction to usage instructions for `APACHE_LOAD_MODULES`; the required modules were incorrect in the example.
 - Adds `PHP_OPTIONS_SESSION_NAME` to optionally set PHP session.name.
+- Deprecates use of the fleet `--manager` option in the `scmi` installer.
 
 ### 2.2.2 - 2017-12-25
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ $ docker run \
 
 ##### SCMI Fleet Support
 
+**_Deprecation Notice:_** The fleet project is no longer maintained. The fleet `--manager` option has been deprecated in `scmi`.
+
 If your docker host has systemd, fleetd (and optionally etcd) installed then `scmi` provides a method to schedule the container  to run on the cluster. This provides some additional features for managing a group of instances on a [fleet](https://github.com/coreos/fleet) cluster and has the option to use an etcd backed service registry. To use the fleet method of installation use the `-m` or `--manager` option of `scmi` and to include the optional etcd register companion unit use the `--register` option.
 
 ##### SCMI Image Information


### PR DESCRIPTION
Resolves #501 

- Deprecates use of the fleet `--manager` option in the `scmi` installer.