### PR TITLE
CLOSES #502: Patches back #501.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).
 - Updates php-hello-world to [0.6.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.6.0).
 - Adds `PHP_OPTIONS_SESSION_NAME` to optionally set PHP session.name.
+- Deprecates use of the fleet `--manager` option in the `scmi` installer.
 
 ### 1.10.2 - 2017-12-25
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ $ docker run \
 
 ##### SCMI Fleet Support
 
+**_Deprecation Notice:_** The fleet project is no longer maintained. The fleet `--manager` option has been deprecated in `scmi`.
+
 If your docker host has systemd, fleetd (and optionally etcd) installed then `scmi` provides a method to schedule the container  to run on the cluster. This provides some additional features for managing a group of instances on a [fleet](https://github.com/coreos/fleet) cluster and has the option to use an etcd backed service registry. To use the fleet method of installation use the `-m` or `--manager` option of `scmi` and to include the optional etcd register companion unit use the `--register` option.
 
 ##### SCMI Image Information


### PR DESCRIPTION
Resolves #502

- Deprecates use of the fleet `--manager` option in the `scmi` installer.