### PR TITLE
CLOSES #508: Fixes issue with unusable healthcheck error messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 2.
 
 CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
 
+### 2.2.4 - Unreleased
+
+- Fixes issue with unusable healthcheck error messages.
+
 ### 2.2.3 - 2018-01-16
 
 - Updates `php56u` packages to 5.6.33-1.

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -41,9 +41,9 @@ function __last_check_passed ()
 
 function __print_message ()
 {
-	local -r message="${2:-}"
 	local -r type="${1:-}"
 	local -r quiet=${QUIET:-false}
+	local message="${2:-}"
 	local prefix=""
 
 	case "${type}" in


### PR DESCRIPTION
CLOSES #508 

- Fixes issue with unusable healthcheck error messages.