### PR TITLE
CLOSES #509: Patches back #508.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
+### 1.10.4 - Unreleased
+
+- Fixes issue with unusable healthcheck error messages.
+
 ### 1.10.3 - 2018-01-16
 
 - Updates source image to [1.8.3 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.3).

--- a/src/usr/bin/healthcheck
+++ b/src/usr/bin/healthcheck
@@ -41,9 +41,9 @@ function __last_check_passed ()
 
 function __print_message ()
 {
-	local -r message="${2:-}"
 	local -r type="${1:-}"
 	local -r quiet=${QUIET:-false}
+	local message="${2:-}"
 	local prefix=""
 
 	case "${type}" in


### PR DESCRIPTION
CLOSES #509: Patches back #508.

- Fixes issue with unusable healthcheck error messages.