### PR TITLE
CLOSES #507: Adds correction to error log location/level usage example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 ### 2.2.4 - Unreleased
 
 - Fixes issue with unusable healthcheck error messages.
+- Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.
 
 ### 2.2.3 - 2018-01-16
 

--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ The Apache ErrorLog can be defined using `APACHE_ERROR_LOG_LOCATION` to set a fi
 
 ```
 ...
-  --env "APACHE_CUSTOM_LOG_LOCATION=/var/log/httpd/error_log" \
-  --env "APACHE_CUSTOM_LOG_FORMAT=error" \
+  --env "APACHE_ERROR_LOG_LOCATION=/var/log/httpd/error_log" \
+  --env "APACHE_ERROR_LOG_LEVEL=error" \
 ...
 ```
 


### PR DESCRIPTION
CLOSES #507

- Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.