### PR TITLE
CLOSES #510: Fix PHP environment variable replacement issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 
 - Fixes issue with unusable healthcheck error messages.
 - Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.
+- Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.
 
 ### 2.2.3 - 2018-01-16
 

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -423,10 +423,26 @@ function load_php_ini_scan_files ()
 	local PACKAGE_PATH="${1:-}"
 	local SCAN_DIRECTORY="/etc/php.d"
 
+	for FILE_PATH in "${SCAN_DIRECTORY}"/*.ini
+	do
+		# Replace environment variables
+		printf -- \
+			'%s' \
+			"$(
+				eval \
+					"cat <<-EOF
+						$(<"${FILE_PATH}")
+					EOF" 2> /dev/null
+			)" \
+		> "${SCAN_DIRECTORY}/${FILE_PATH##*/}"
+	done
+
 	if [[ -n ${PACKAGE_PATH} ]] \
-		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
-		# Replace environment variables to support fcgid php-wrapper
-		for FILE_PATH in /etc/php.d/*.ini "${PACKAGE_PATH}"/etc/php.d/*.ini; do
+		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]
+	then
+		for FILE_PATH in "${PACKAGE_PATH}/${SCAN_DIRECTORY}"/*.ini
+		do
+			# Replace environment variables
 			printf -- \
 				'%s' \
 				"$(

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -417,14 +417,15 @@ function load_httpd_conf_scan_files ()
 	fi
 }
 
-function load_php_ini_scan_files ()
+function load_php_ini_scan_file ()
 {
-	local FILE_PATH
-	local PACKAGE_PATH="${1:-}"
-	local SCAN_DIRECTORY="/etc/php.d"
+	local FILE_PATH="${1:-}"
+	local SCAN_DIRECTORY="${2:-}"
 
-	for FILE_PATH in "${SCAN_DIRECTORY}"/*.ini
-	do
+	if [[ -n ${SCAN_DIRECTORY} ]] \
+		&& [[ -n ${FILE_PATH} ]] \
+		&& [[ -s ${FILE_PATH} ]]
+	then
 		# Replace environment variables
 		printf -- \
 			'%s' \
@@ -435,6 +436,20 @@ function load_php_ini_scan_files ()
 					EOF" 2> /dev/null
 			)" \
 		> "${SCAN_DIRECTORY}/${FILE_PATH##*/}"
+	fi
+}
+
+function load_php_ini_scan_files ()
+{
+	local FILE_PATH
+	local PACKAGE_PATH="${1:-}"
+	local SCAN_DIRECTORY="/etc/php.d"
+
+	for FILE_PATH in "${SCAN_DIRECTORY}"/*.ini
+	do
+		load_php_ini_scan_file \
+			"${FILE_PATH}" \
+			"${SCAN_DIRECTORY}"
 	done
 
 	if [[ -n ${PACKAGE_PATH} ]] \
@@ -442,16 +457,9 @@ function load_php_ini_scan_files ()
 	then
 		for FILE_PATH in "${PACKAGE_PATH}/${SCAN_DIRECTORY}"/*.ini
 		do
-			# Replace environment variables
-			printf -- \
-				'%s' \
-				"$(
-					eval \
-						"cat <<-EOF
-							$(<"${FILE_PATH}")
-						EOF" 2> /dev/null
-				)" \
-			> "${SCAN_DIRECTORY}/${FILE_PATH##*/}"
+			load_php_ini_scan_file \
+				"${FILE_PATH}" \
+				"${SCAN_DIRECTORY}"
 		done
 	fi
 }


### PR DESCRIPTION
CLOSES #510

- Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.