### PR TITLE
CLOSES #512: Patches back #510.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
 - Fixes issue with unusable healthcheck error messages.
 - Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.
+- Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.
 
 ### 1.10.3 - 2018-01-16
 

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -320,24 +320,49 @@ function load_httpd_conf_scan_files ()
 	fi
 }
 
+function load_php_ini_scan_file ()
+{
+	local FILE_PATH="${1:-}"
+	local SCAN_DIRECTORY="${2:-}"
+
+	if [[ -n ${SCAN_DIRECTORY} ]] \
+		&& [[ -n ${FILE_PATH} ]] \
+		&& [[ -s ${FILE_PATH} ]]
+	then
+		# Replace environment variables
+		printf -- \
+			'%s' \
+			"$(
+				eval \
+					"cat <<-EOF
+						$(<"${FILE_PATH}")
+					EOF" 2> /dev/null
+			)" \
+		> "${SCAN_DIRECTORY}/${FILE_PATH##*/}"
+	fi
+}
+
 function load_php_ini_scan_files ()
 {
 	local FILE_PATH
 	local PACKAGE_PATH="${1:-}"
+	local SCAN_DIRECTORY="/etc/php.d"
+
+	for FILE_PATH in "${SCAN_DIRECTORY}"/*.ini
+	do
+		load_php_ini_scan_file \
+			"${FILE_PATH}" \
+			"${SCAN_DIRECTORY}"
+	done
 
 	if [[ -n ${PACKAGE_PATH} ]] \
-		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]; then
-		# Replace environment variables to support fcgid php-wrapper
-		for FILE_PATH in /etc/php.d/*.ini "${PACKAGE_PATH}"/etc/php.d/*.ini; do
-			printf -- \
-				'%s' \
-				"$(
-					eval \
-						"cat <<-EOF
-							$(<"${FILE_PATH}")
-						EOF" 2> /dev/null
-				)" \
-			> "/etc/php.d/${FILE_PATH##*/}"
+		&& [[ -d ${PACKAGE_PATH}/etc/php.d ]]
+	then
+		for FILE_PATH in "${PACKAGE_PATH}/${SCAN_DIRECTORY}"/*.ini
+		do
+			load_php_ini_scan_file \
+				"${FILE_PATH}" \
+				"${SCAN_DIRECTORY}"
 		done
 	fi
 }


### PR DESCRIPTION
CLOSES #512: Patches back #510.

- Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.