### PR TITLE
CLOSES #521: Patches back #520.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Fixes issue with unusable healthcheck error messages.
 - Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.
 - Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.
+- Fixes prerequisite test when testing disable wrapper features.
 
 ### 1.10.3 - 2018-01-16
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -686,6 +686,7 @@ function test_custom_configuration ()
 	local curl_session_name=""
 	local header_x_service_operating_mode=""
 	local header_x_service_uid=""
+	local is_up=""
 	local php_date_timezone=""
 	local protocol=""
 
@@ -1987,16 +1988,23 @@ function test_custom_configuration ()
 
 			# Healthcheck should fail unless running PHP-FPM without Apache.
 			it "Can disable httpd-bootstrap."
+				is_up="1"
+
 				docker ps \
-					--format "name=apache-php.pool-1.1.1" \
-				&> /dev/null \
-				&& docker top \
+					--quiet \
+					--filter "name=apache-php.pool-1.1.1" \
+					--filter "health=unhealthy" \
+				&> /dev/null
+				is_up="${?}"
+
+				docker top \
 					apache-php.pool-1.1.1 \
+				&> /dev/null \
 				| grep -qE '/usr/sbin/httpd(\.worker|\.event)? '
 
 				assert equal \
-					"${?}" \
-					"1"
+					"${is_up}:${?}" \
+					"0:1"
 			end
 
 			__terminate_container \
@@ -2013,17 +2021,22 @@ function test_custom_configuration ()
 			sleep ${STARTUP_TIME}
 
 			it "Can disable httpd-wrapper."
+				is_up="1"
+
 				docker ps \
-					--format "name=apache-php.pool-1.1.1" \
-					--format "health=healthy" \
-				&> /dev/null \
-				&& docker top \
+					--filter "name=apache-php.pool-1.1.1" \
+					--filter "health=healthy" \
+				&> /dev/null
+				is_up="${?}"
+
+				docker top \
 					apache-php.pool-1.1.1 \
+				&> /dev/null \
 				| grep -qE '/usr/sbin/httpd(\.worker|\.event)? '
 
 				assert equal \
-					"${?}" \
-					"1"
+					"${is_up}:${?}" \
+					"0:1"
 			end
 
 			__terminate_container \


### PR DESCRIPTION
CLOSES #521: Patches back #520.

- Fixes prerequisite test when testing disable wrapper features.
