### PR TITLE
CLOSES #524: Patches back #513.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Adds correction to README.md example for usage of `APACHE_ERROR_LOG_LOCATION` and `APACHE_ERROR_LOG_LEVEL`.
 - Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.
 - Fixes prerequisite test when testing disable wrapper features.
+- Adds exclusion of internal "Docker-Healthcheck" requests from the access log.
 
 ### 1.10.3 - 2018-01-16
 

--- a/src/etc/services-config/httpd/conf.virtualhost.d/00-log.conf
+++ b/src/etc/services-config/httpd/conf.virtualhost.d/00-log.conf
@@ -1,5 +1,16 @@
 ErrorLog "${APACHE_ERROR_LOG_LOCATION}"
 LogLevel "${APACHE_ERROR_LOG_LEVEL}"
 <IfModule mod_log_config.c>
-    CustomLog "${APACHE_CUSTOM_LOG_LOCATION}" "${APACHE_CUSTOM_LOG_FORMAT}"
+    CustomLog "${APACHE_CUSTOM_LOG_LOCATION}" "${APACHE_CUSTOM_LOG_FORMAT}" env=!SKIP_CUSTOM_LOG
+</IfModule>
+<IfModule mod_setenvif.c>
+    <IfVersion < 2.4>
+        SetEnvIf Request_Method ".*" TRUSTED_ADDRESS=false
+        SetEnvIf Remote_Addr "^127\.0\.0\.1$" TRUSTED_ADDRESS=true
+        SetEnvIf User-Agent "^Docker-Healthcheck$" SKIP_CUSTOM_LOG
+        SetEnvIf TRUSTED_ADDRESS "false" !SKIP_CUSTOM_LOG
+    </IfVersion>
+    <IfVersion >= 2.4>
+        SetEnvIfExpr "-R '127.0.0.1' && %{HTTP_USER_AGENT} == 'Docker-Healthcheck'" SKIP_CUSTOM_LOG
+    </IfVersion>
 </IfModule>


### PR DESCRIPTION
CLOSES #524: Patches back #513.

- Adds exclusion of internal "Docker-Healthcheck" requests from the access log.