### PR TITLE
CLOSES #382: Adds OCSP Stapling cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-6 6.9 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.
 - Fixes issue with environment variables not getting replaced within PHP files in the default scan directory when a app package is installed that contains no custom PHP drop-in configuration files.
 - Fixes prerequisite test when testing disable wrapper features.
 - Adds exclusion of internal "Docker-Healthcheck" requests from the access log.
+- Adds configuration to enable Apache OCSP Stapling with a CA signed certificate.
 
 ### 2.2.3 - 2018-01-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,8 +123,9 @@ RUN sed -i \
 # -----------------------------------------------------------------------------
 # Disable SSL + the default SSL Virtual Host
 # -----------------------------------------------------------------------------
-RUN sed -i \
+RUN sed -ri \
 		-e '/<VirtualHost _default_:443>/,/<\/VirtualHost>/ s~^~#~' \
+		-e 's~(SSLSessionCacheTimeout.*)$~\1\n\nSSLUseStapling on\nSSLStaplingCache shmcb:/var/run/httpd/sslstaplingcache(512000)\nSSLStaplingResponderTimeout 5\nSSLStaplingReturnResponderErrors off~' \
 		/etc/httpd/conf.d/ssl.conf \
 	&& cat \
 		/etc/httpd/conf.d/ssl.conf \

--- a/src/etc/services-config/httpd/conf.d/ssl.conf.default
+++ b/src/etc/services-config/httpd/conf.d/ssl.conf.default
@@ -1,21 +1,8 @@
 #
-# This is the Apache server configuration file providing SSL support.
-# It contains the configuration directives to instruct the server how to
-# serve pages over an https connection. For detailing information about these 
-# directives see <URL:http://httpd.apache.org/docs/2.2/mod/mod_ssl.html>
-# 
-# Do NOT simply read the instructions in here without understanding
-# what they do.  They're here only as hints or reminders.  If you are unsure
-# consult the online docs. You have been warned.  
-#
-
-LoadModule ssl_module modules/mod_ssl.so
-
-#
 # When we also provide SSL we have to listen to the 
-# the HTTPS port in addition.
+# standard HTTPS port in addition.
 #
-Listen 443
+Listen 443 https
 
 ##
 ##  SSL Global Context
@@ -26,20 +13,15 @@ Listen 443
 
 #   Pass Phrase Dialog:
 #   Configure the pass phrase gathering process.
-#   The filtering dialog program (`builtin' is a internal
+#   The filtering dialog program (`builtin' is an internal
 #   terminal dialog) has to provide the pass phrase on stdout.
-SSLPassPhraseDialog  builtin
+SSLPassPhraseDialog exec:/usr/libexec/httpd-ssl-pass-dialog
 
 #   Inter-Process Session Cache:
 #   Configure the SSL Session Cache: First the mechanism 
 #   to use and second the expiring timeout (in seconds).
-SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
+SSLSessionCache         shmcb:/var/run/httpd/sslcache(512000)
 SSLSessionCacheTimeout  300
-
-#   Semaphore:
-#   Configure the path to the mutual exclusion semaphore the
-#   SSL engine uses internally for inter-process synchronization. 
-SSLMutex default
 
 #   Pseudo Random Number Generator (PRNG):
 #   Configure one or more sources to seed the PRNG of the 
@@ -87,21 +69,34 @@ LogLevel warn
 #   Enable/Disable SSL for this virtual host.
 SSLEngine on
 
-#   SSL Protocol support:
-# List the enable protocol levels with which clients will be able to
-# connect.  Disable SSLv2 access by default:
-SSLProtocol all -SSLv2
+#   List the protocol versions which clients are allowed to connect with.
+#   Disable SSLv3 by default (cf. RFC 7525 3.1.1).  TLSv1 (1.0) should be
+#   disabled as quickly as practical.
+SSLProtocol all -SSLv3
+SSLProxyProtocol all -SSLv3
+
+#   User agents such as web browsers are not configured for the user's
+#   own preference of either security or performance, therefore this
+#   must be the prerogative of the web server administrator who manages
+#   cpu load versus confidentiality, so enforce the server's cipher order.
+SSLHonorCipherOrder on
 
 #   SSL Cipher Suite:
-# List the ciphers that the client is permitted to negotiate.
-# See the mod_ssl documentation for a complete list.
-SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+#   List the ciphers that the client is permitted to negotiate.
+#   See the mod_ssl documentation for a complete list.
+#   httpd 2.2.30, 2.4.13 and later force-disable aNULL, eNULL and EXP ciphers.
+SSLCipherSuite HIGH:MEDIUM:!MD5:!RC4
+SSLProxyCipherSuite HIGH:MEDIUM:!MD5:!RC4
 
-#   Server Certificate:
-# Point SSLCertificateFile at a PEM encoded certificate.  If
-# the certificate is encrypted, then you will be prompted for a
-# pass phrase.  Note that a kill -HUP will prompt again.  A new
-# certificate can be generated using the genkey(1) command.
+#   Point SSLCertificateFile at a PEM encoded certificate.  If
+#   the certificate is encrypted, then you will be prompted for a
+#   pass phrase.  Note that a kill -HUP will prompt again.  Keep
+#   in mind that if you have both an RSA and a DSA certificate you
+#   can configure both in parallel (to also allow the use of DSA
+#   ciphers, etc.)
+#   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
+#   require an ECC certificate which can also be configured in
+#   parallel.
 SSLCertificateFile /etc/pki/tls/certs/localhost.crt
 
 #   Server Private Key:
@@ -109,6 +104,7 @@ SSLCertificateFile /etc/pki/tls/certs/localhost.crt
 #   directive to point at the key file.  Keep in mind that if
 #   you've both a RSA and a DSA private key you can configure
 #   both in parallel (to also allow the use of DSA ciphers, etc.)
+#   ECC keys, when in use, can also be configured in parallel
 SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 
 #   Server Certificate Chain:
@@ -117,7 +113,7 @@ SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 #   certificate chain for the server certificate. Alternatively
 #   the referenced file can be the same as SSLCertificateFile
 #   when the CA certificates are directly appended to the server
-#   certificate for convinience.
+#   certificate for convenience.
 #SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
 
 #   Certificate Authority (CA):
@@ -177,9 +173,9 @@ SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 #     This enables optimized SSL connection renegotiation handling when SSL
 #     directives are used in per-directory context. 
 #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
-<Files ~ "\.(cgi|shtml|phtml|php3?)$">
+<FilesMatch "\.(cgi|shtml|phtml|php)$">
     SSLOptions +StdEnvVars
-</Files>
+</FilesMatch>
 <Directory "/var/www/cgi-bin">
     SSLOptions +StdEnvVars
 </Directory>
@@ -191,13 +187,13 @@ SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 #   approach you can use one of the following variables:
 #   o ssl-unclean-shutdown:
 #     This forces an unclean shutdown when the connection is closed, i.e. no
-#     SSL close notify alert is send or allowed to received.  This violates
+#     SSL close notify alert is sent or allowed to be received.  This violates
 #     the SSL/TLS standard but is needed for some brain-dead browsers. Use
 #     this when you receive I/O errors because of the standard approach where
 #     mod_ssl sends the close notify alert.
 #   o ssl-accurate-shutdown:
 #     This forces an accurate shutdown when the connection is closed, i.e. a
-#     SSL close notify alert is send and mod_ssl waits for the close notify
+#     SSL close notify alert is sent and mod_ssl waits for the close notify
 #     alert of the client. This is 100% SSL/TLS standard compliant, but in
 #     practice often causes hanging connections with brain-dead browsers. Use
 #     this only for browsers where you know that their SSL implementation
@@ -208,7 +204,7 @@ SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
 #   Similarly, one has to force some clients to use HTTP/1.0 to workaround
 #   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
 #   "force-response-1.0" for this.
-SetEnvIf User-Agent ".*MSIE.*" \
+BrowserMatch "MSIE [2-5]" \
          nokeepalive ssl-unclean-shutdown \
          downgrade-1.0 force-response-1.0
 
@@ -218,5 +214,4 @@ SetEnvIf User-Agent ".*MSIE.*" \
 CustomLog logs/ssl_request_log \
           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
-</VirtualHost>                                  
-
+</VirtualHost>

--- a/src/etc/services-config/httpd/conf.modules.d/00-ssl.conf.default
+++ b/src/etc/services-config/httpd/conf.modules.d/00-ssl.conf.default
@@ -1,0 +1,1 @@
+LoadModule ssl_module modules/mod_ssl.so


### PR DESCRIPTION
CLOSES #382 

- Adds configuration to enable Apache OCSP Stapling with a CA signed certificate.
- Updates reference copies of Apache 2.4 TLS/SSL configuration files (unused in image).