### PR TITLE
CLOSES #535: Patches back #286.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.9 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 ### 1.10.5 - Unreleased
 
 - Updates source image to [1.8.4 tag](https://github.com/jdeathe/centos-ssh/releases/tag/1.8.4).
+- Adds feature to set `APACHE_SSL_CERTIFICATE` via a file path. e.g. Docker Swarm secrets.
 
 ### 1.10.4 - 2018-01-27
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -217,9 +217,6 @@ RUN mkdir -p \
 		/etc/services-config/ssl/certs/localhost.crt \
 		/etc/pki/tls/certs/localhost.crt \
 	&& ln -sf \
-		/etc/services-config/ssl/private/localhost.key \
-		/etc/pki/tls/private/localhost.key \
-	&& ln -sf \
 		/etc/services-config/supervisor/supervisord.conf \
 		/etc/supervisord.conf \
 	&& ln -sf \

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ The public directory is relative to the `APACHE_CONTENT_ROOT` and together they 
 
 ##### APACHE_SSL_CERTIFICATE
 
-The `APACHE_SSL_CERTIFICATE` environment variable is used to define a PEM, (and optionally base64), encoded certificate bundle. Base64 encoding of the PEM file contents is recommended. To make a compatible certificate bundle use the `cat` command to combine the certificate files together.
+The `APACHE_SSL_CERTIFICATE` environment variable is used to define a PEM encoded certificate bundle. To make a compatible certificate bundle use the `cat` command to combine the certificate files together.
 
 ```
 $ cat /usr/share/private/server-key.pem \
@@ -381,6 +381,8 @@ $ cat /usr/share/private/server-key.pem \
   > /usr/share/certs/server-bundle.pem
 ```
 
+Base64 encoding of the PEM file contents is recommended if not using the file path method.
+
 *Note:* The `base64` command on Mac OSX will encode a file without line breaks by default but if using the command on Linux you need to include use the `-w` option to prevent wrapping lines at 80 characters. i.e. `base64 -w 0 -i {certificate-path}`.
 
 ```
@@ -388,6 +390,14 @@ $ cat /usr/share/private/server-key.pem \
   --env "APACHE_SSL_CERTIFICATE=$(
     base64 -i "/usr/share/certs/server-bundle.pem"
   )" \
+...
+```
+
+If set to a valid container file path the value will be read from the file - this allows for setting the value securely when combined with an orchestration feature such as Docker Swarm secrets.
+
+```
+...
+  --env "APACHE_SSL_CERTIFICATE=/run/secrets/apache_ssl_certificate" \
 ...
 ```
 

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -208,13 +208,14 @@ function get_password ()
 
 function get_ssl_certificate_fingerprint ()
 {
-	local DIGEST="${1:-sha1}"
+	local -r DIGEST="${1:-sha1}"
+	local -r FILE_PATH="${2:-/etc/pki/tls/certs/localhost.crt}"
 	local VALUE
 
 	VALUE="$(
 		openssl x509 \
 			-"${DIGEST,,}" \
-			-in /etc/services-config/ssl/certs/localhost.crt \
+			-in "${FILE_PATH}" \
 			-noout \
 			-fingerprint
 	)"
@@ -223,7 +224,6 @@ function get_ssl_certificate_fingerprint ()
 
 	printf -- "%s" "${VALUE}"
 }
-
 
 function is_valid_apache_content_root ()
 {
@@ -265,14 +265,15 @@ function is_valid_apache_public_directory ()
 
 function is_valid_apache_ssl_certificate ()
 {
-	local VALID_PATTERN='^SHA1 Fingerprint='
+	local -r FILE_PATH="${1:-/etc/pki/tls/certs/localhost.crt}"
+	local -r VALID_PATTERN='^SHA1 Fingerprint='
 	local SHA1_FINGERPRINT
 
 	SHA1_FINGERPRINT="$(
 		openssl \
 			x509 \
 			-sha1 \
-			-in /etc/services-config/ssl/certs/localhost.crt \
+			-in "${FILE_PATH}" \
 			-noout \
 			-fingerprint
 	)"
@@ -398,7 +399,7 @@ function make_self_signed_san_certificate ()
 	cat \
 		/etc/pki/tls/openssl.cnf \
 		- \
-		<<-CONFIG > /etc/services-config/ssl/certs/localhost.cnf
+		<<-CONFIG > /etc/pki/tls/certs/localhost.cnf
 
 	[ san ]
 	subjectAltName="${SAN:-root@localhost.localdomain}"
@@ -414,9 +415,9 @@ function make_self_signed_san_certificate ()
 		-reqexts san \
 		-extensions san \
 		-subj "/CN=${CN}" \
-		-config /etc/services-config/ssl/certs/localhost.cnf \
-		-keyout /etc/services-config/ssl/certs/localhost.crt \
-		-out /etc/services-config/ssl/certs/localhost.crt
+		-config /etc/pki/tls/certs/localhost.cnf \
+		-keyout /etc/pki/tls/certs/localhost.crt \
+		-out /etc/pki/tls/certs/localhost.crt
 
 }
 
@@ -549,9 +550,10 @@ function set_apache_server_name ()
 
 function set_apache_ssl_certificate ()
 {
+	local -r FILE_PATH='/etc/pki/tls/certs/localhost.crt'
+	local -r BASE64_PATTERN='^[A-Za-z0-9/+=]*$'
+	local -r PLAIN_TEXT_PATTERN='^-----BEGIN '
 	local SSL_CERTIFICATE="${1:-}"
-	local PLAIN_TEXT_PATTERN='^-----BEGIN '
-	local BASE64_PATTERN='^[A-Za-z0-9/+=]*$'
 
 	if [[ -n ${SSL_CERTIFICATE} ]]; then
 		# Decode base64 encoded values
@@ -561,21 +563,30 @@ function set_apache_ssl_certificate ()
 			)"
 		fi
 
-		if [[ ! ${SSL_CERTIFICATE} =~ ${PLAIN_TEXT_PATTERN} ]]; then
-			printf -- \
-				'ERROR: Invalid APACHE_SSL_CERTIFICATE\n' \
-				>&2
-			sleep 0.1
-			exit 1
+		if [[ -s ${SSL_CERTIFICATE} ]] \
+			&& [[ ${SSL_CERTIFICATE} != ${FILE_PATH} ]]
+		then
+			ln -sf \
+				"${SSL_CERTIFICATE}" \
+				"${FILE_PATH}"
+		else
+			if [[ ! ${SSL_CERTIFICATE} =~ ${PLAIN_TEXT_PATTERN} ]]; then
+				printf -- \
+					'ERROR: Invalid APACHE_SSL_CERTIFICATE\n' \
+					>&2
+				sleep 0.1
+				exit 1
+			fi
+
+			printf \
+				-- '%s' \
+				"${SSL_CERTIFICATE}" \
+			> "${FILE_PATH}"
 		fi
 
-		printf \
-			-- '%s' \
-			"${SSL_CERTIFICATE}" \
-		> /etc/services-config/ssl/certs/localhost.crt
-
-		if [[ -s /etc/services-config/ssl/certs/localhost.crt ]] \
-			&& ! is_valid_apache_ssl_certificate; then
+		if ! is_valid_apache_ssl_certificate \
+			"${FILE_PATH}"
+		then
 			printf -- \
 				'ERROR: Invalid APACHE_SSL_CERTIFICATE\n' \
 				>&2
@@ -682,13 +693,13 @@ load_php_ini_scan_files "${PACKAGE_PATH}"
 
 # Populate SSL certificate file.
 if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
-	&& [[ -n ${OPTS_APACHE_SSL_CERTIFICATE} ]]; then
-	set_apache_ssl_certificate "${OPTS_APACHE_SSL_CERTIFICATE}"
-fi
-
-# Generate SSL certificate.
-if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
-	&& [[ ! -f /etc/services-config/ssl/certs/localhost.crt ]]; then
+	&& [[ -n ${OPTS_APACHE_SSL_CERTIFICATE} ]]
+then
+	set_apache_ssl_certificate \
+		"${OPTS_APACHE_SSL_CERTIFICATE}"
+elif [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]] \
+	&& [[ -z ${OPTS_APACHE_SSL_CERTIFICATE} ]]
+then
 	make_self_signed_san_certificate \
 		"${OPTS_APACHE_SERVER_NAME}" \
 		"${OPTS_APACHE_SERVER_ALIAS}" \
@@ -848,7 +859,8 @@ if [[ ${OPTS_APACHE_MOD_SSL_ENABLED} == true ]]; then
 	DIGEST=sha1
 	FINGERPRINT="$(
 		get_ssl_certificate_fingerprint \
-			"${DIGEST}"
+			"${DIGEST}" \
+			"/etc/pki/tls/certs/localhost.crt"
 	)"
 
 	printf -v \

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -89,7 +89,7 @@ function __setup ()
 	local -r session_store_alias="memcached_1"
 	local -r session_store_name="memcached.pool-1.1.1"
 	local -r session_store_network="bridge_internal_1"
-	local -r session_store_release="1.1.2"
+	local -r session_store_release="1.1.3"
 
 	if [[ -z $(docker network ls -q -f name="${session_store_network}") ]]; then
 		docker network create \
@@ -1773,11 +1773,7 @@ function test_custom_configuration ()
 					"200"
 			end
 
-			it "Sets static certificate."
-				__terminate_container \
-					apache-php.pool-1.1.1 \
-				&> /dev/null
-
+			describe "Static certificate."
 				if [[ -s /tmp/www.app-1.local.pem ]]; then
 					certificate_fingerprint_file="$(
 						cat \
@@ -1806,52 +1802,112 @@ function test_custom_configuration ()
 					fi
 				fi
 
-				docker run \
-					--detach \
-					--name apache-php.pool-1.1.1 \
-					--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
-					--env APACHE_MOD_SSL_ENABLED="true" \
-					--env APACHE_SERVER_NAME="www.app-1.local" \
-					--env APACHE_SSL_CERTIFICATE="${certificate_pem_base64}" \
-					jdeathe/centos-ssh-apache-php:latest \
-				&> /dev/null
-
-				container_port_443="$(
-					__get_container_port \
+				it "Sets from base64 encoded value."
+					__terminate_container \
 						apache-php.pool-1.1.1 \
-						443/tcp
-				)"
+					&> /dev/null
 
-				if ! __is_container_ready \
-					apache-php.pool-1.1.1 \
-					${STARTUP_TIME} \
-					"/usr/sbin/httpd(\.worker|\.event)? " \
-					"[[ 000 != \$(curl -sI -o /dev/null -w %{http_code} localhost/) ]]"
-				then
-					exit 1
-				fi
+					docker run \
+						--detach \
+						--name apache-php.pool-1.1.1 \
+						--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+						--env APACHE_MOD_SSL_ENABLED="true" \
+						--env APACHE_SERVER_NAME="www.app-1.local" \
+						--env APACHE_SSL_CERTIFICATE="${certificate_pem_base64}" \
+						jdeathe/centos-ssh-apache-php:latest \
+					&> /dev/null
 
-				certificate_fingerprint_server="$(
-					echo -n \
-					| openssl s_client \
-						-connect 127.0.0.1:${container_port_443} \
-						-CAfile /tmp/www.app-1.local.pem \
-						-nbio \
-						2>&1 \
-					| sed \
-						-n \
-						-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
-					| openssl \
-						x509 \
-						-fingerprint \
-						-noout \
-					| sed \
-						-e 's~SHA1 Fingerprint=~~'
-				)"
+					container_port_443="$(
+						__get_container_port \
+							apache-php.pool-1.1.1 \
+							443/tcp
+					)"
 
-				assert equal \
-					"${certificate_fingerprint_server}" \
-					"${certificate_fingerprint_file}"
+					if ! __is_container_ready \
+						apache-php.pool-1.1.1 \
+						${STARTUP_TIME} \
+						"/usr/sbin/httpd(\.worker|\.event)? " \
+						"[[ 000 != \$(curl -sI -o /dev/null -w %{http_code} localhost/) ]]"
+					then
+						exit 1
+					fi
+
+					certificate_fingerprint_server="$(
+						echo -n \
+						| openssl s_client \
+							-connect 127.0.0.1:${container_port_443} \
+							-CAfile /tmp/www.app-1.local.pem \
+							-nbio \
+							2>&1 \
+						| sed \
+							-n \
+							-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
+						| openssl \
+							x509 \
+							-fingerprint \
+							-noout \
+						| sed \
+							-e 's~SHA1 Fingerprint=~~'
+					)"
+
+					assert equal \
+						"${certificate_fingerprint_server}" \
+						"${certificate_fingerprint_file}"
+				end
+
+				it "Sets from file path value."
+					__terminate_container \
+						apache-php.pool-1.1.1 \
+					&> /dev/null
+
+					docker run \
+						--detach \
+						--name apache-php.pool-1.1.1 \
+						--publish ${DOCKER_PORT_MAP_TCP_443}:443 \
+						--env APACHE_MOD_SSL_ENABLED="true" \
+						--env APACHE_SERVER_NAME="www.app-1.local" \
+						--env APACHE_SSL_CERTIFICATE="/var/run/tmp/www.app-1.local.pem" \
+						--volume /tmp:/var/run/tmp:ro \
+						jdeathe/centos-ssh-apache-php:latest \
+					&> /dev/null
+
+					container_port_443="$(
+						__get_container_port \
+							apache-php.pool-1.1.1 \
+							443/tcp
+					)"
+
+					if ! __is_container_ready \
+						apache-php.pool-1.1.1 \
+						${STARTUP_TIME} \
+						"/usr/sbin/httpd(\.worker|\.event)? " \
+						"[[ 000 != \$(curl -sI -o /dev/null -w %{http_code} localhost/) ]]"
+					then
+						exit 1
+					fi
+
+					certificate_fingerprint_server="$(
+						echo -n \
+						| openssl s_client \
+							-connect 127.0.0.1:${container_port_443} \
+							-CAfile /tmp/www.app-1.local.pem \
+							-nbio \
+							2>&1 \
+						| sed \
+							-n \
+							-e '/^-----BEGIN CERTIFICATE-----$/,/^-----END CERTIFICATE-----$/p' \
+						| openssl \
+							x509 \
+							-fingerprint \
+							-noout \
+						| sed \
+							-e 's~SHA1 Fingerprint=~~'
+					)"
+
+					assert equal \
+						"${certificate_fingerprint_server}" \
+						"${certificate_fingerprint_file}"
+				end
 			end
 
 			it "Sets cipher suite."


### PR DESCRIPTION
CLOSES #535: Patches back #286.

- Adds feature to set `APACHE_SSL_CERTIFICATE` via a file path. e.g. Docker Swarm secrets.