### PR TITLE
CLOSES #559: Removes image files added by the centos-logos package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-7 7.4.1708 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcac
 ### 3.0.1 - Unreleased
 
 - Updates php-hello-world to [0.9.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.9.0).
+- Removes ~20MB of image files added by the `centos-logos` package.
 
 ### 3.0.0 - 2018-06-15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,12 @@ RUN rpm --rebuilddb \
 		httpd24u* \
 		php72u* \
 	&& rm -rf /var/cache/yum/* \
-	&& yum clean all
+	&& yum clean all \
+	&& /bin/find /usr/share \
+		-type f \
+		-regextype posix-extended \
+		-regex '.*\.(jpg|png)$' \
+		-delete
 
 # -----------------------------------------------------------------------------
 # Global Apache configuration changes


### PR DESCRIPTION
CLOSES #559

- Removes ~20MB of image files added by the `centos-logos` package.