### PR TITLE
CLOSES #570: Removes INode component from ETag headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 - Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
 - Updates php-hello-world to [0.10.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.10.0).
 - Adds web fonts to expires rules.
+- Adds FileETag configuration removing INode from the Apache 2.2 default.
 
 ### 1.10.6 - 2018-06-20
 

--- a/src/etc/services-config/httpd/conf.d/00-etag.conf
+++ b/src/etc/services-config/httpd/conf.d/00-etag.conf
@@ -1,0 +1,6 @@
+<IfVersion < 2.4>
+    # Change the default from "INode MTime Size".
+    # Note: If using WebDAV (mod_dav_fs) you must restore the default at the
+    # effected locations otherwise conditional requests will break.
+    FileETag MTime Size
+</IfVersion>


### PR DESCRIPTION
CLOSES #570

- Adds FileETag configuration removing INode from the Apache 2.2 default.