### PR TITLE
CLOSES #606: Patches back #605.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7
 
 - Updates `php56u` packages to 5.6.38-1.
 - Updates `httpd24u` packages to 2.4.35-1.
+- Adds improved example of `apachectl` usage via docker exec.
 
 ### 2.3.0 - 2018-09-03
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ On first run, the bootstrap script, ([/usr/sbin/httpd-bootstrap](https://github.
 The `apachectl` command can be accessed as follows.
 
 ```
-$ docker exec -it apache-php.pool-1.1.1 apachectl -h
+$ docker exec -it apache-php.pool-1.1.1 \
+	bash -c "apachectl -h"
 ```
 
 ## Instructions


### PR DESCRIPTION
CLOSES #606: Patches back #605.

- Adds improved example of `apachectl` usage via docker exec.