### PR TITLE
CLOSES #607: Patches back #605.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
+### 1.11.1 - Unreleased
+
+- Adds improved example of `apachectl` usage via docker exec.
+
 ### 1.11.0 - 2018-09-03
 
 - Updates `httpd` packages to 2.2.15-69.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ On first run, the bootstrap script, ([/usr/sbin/httpd-bootstrap](https://github.
 The `apachectl` command can be accessed as follows.
 
 ```
-$ docker exec -it apache-php.pool-1.1.1 apachectl -h
+$ docker exec -it apache-php.pool-1.1.1 \
+	bash -c "apachectl -h"
 ```
 
 ## Instructions


### PR DESCRIPTION
CLOSES #607: Patches back #605.

- Adds improved example of `apachectl` usage via docker exec.