### PR TITLE
CLOSES #604: Updates source image to 2.4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcac
 
 - Updates `php72u` packages to 7.2.11-1.
 - Updates `httpd24u` packages to 2.4.35-1.
+- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
 - Adds improved example of `apachectl` usage via docker exec.
 
 ### 3.1.0 - 2018-09-03

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-7, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcache 7.2
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:2.4.0
+FROM jdeathe/centos-ssh:2.4.1
 
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"


### PR DESCRIPTION
CLOSES #604

- Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).