### PR TITLE
CLOSES #623: Adds php-hello-world 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 ### 1.11.1 - Unreleased
 
 - Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).
+- Updates php-hello-world to [0.11.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.11.0).
 - Adds improved example of `apachectl` usage via docker exec.
 - Adds `php-pecl-redis` package to support Redis.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM jdeathe/centos-ssh:1.9.1
 # Use the form ([{fqdn}-]{package-name}|[{fqdn}-]{provider-name})
 ARG PACKAGE_NAME="app"
 ARG PACKAGE_PATH="/opt/${PACKAGE_NAME}"
-ARG PACKAGE_RELEASE_VERSION="0.10.0"
+ARG PACKAGE_RELEASE_VERSION="0.11.0"
 
 # -----------------------------------------------------------------------------
 # Base Apache, PHP
@@ -23,6 +23,7 @@ RUN rpm --rebuilddb \
 		mod_ssl-2.2.15-69.el6.centos \
 		php-5.3.3-49.el6 \
 		php-cli-5.3.3-49.el6 \
+		php-common-5.3.3-49.el6 \
 		php-zts-5.3.3-49.el6 \
 		php-pecl-apc-3.1.9-2.el6 \
 		php-pecl-memcached-1.0.0-1.el6 \


### PR DESCRIPTION
CLOSES #623

- Updates php-hello-world to [0.11.0](https://github.com/jdeathe/php-hello-world/releases/tag/0.11.0).