### PR TITLE
CLOSES #669: Adds PHP redis module info to image description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcac
 ### 3.3.0 - Unreleased
 
 - Updates `php72u` packages to 7.2.18-1.
+- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.
 
 ### 3.2.0 - 2019-04-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -329,7 +329,7 @@ jdeathe/centos-ssh-apache-php:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-apache-php" \
-	org.deathe.description="CentOS-7 7.5.1804 x86_64 - IUS Apache 2.4, IUS PHP-FPM 7.2, PHP memcached 3.0, Zend Opcache 7.2."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - IUS Apache 2.4, IUS PHP-FPM 7.2, PHP memcached 3.0, PHP redis 3.1, Zend Opcache 7.2."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ centos-ssh-apache-php
 
 Docker Image including: 
 
-- CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
-- CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
-- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcache 7.2.
+- CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP redis 2.2, PHP APC 3.1.
+- CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, PHP redis 3.1, Zend Opcache 7.0.
+- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, PHP redis 3.1, Zend Opcache 7.2.
 
 Apache PHP web server, loading only a minimal set of Apache modules by default. Supports custom configuration via environment variables.
 


### PR DESCRIPTION
CLOSES #669

- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.