### PR TITLE
CLOSES #673: Adds PHP redis module info to image description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
 ### 1.13.0 - Unreleased
 
+- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.
 - Fixes php_uname to gethostname replacment regex quoting.
 - Fixes README SSL/TLS data volume names/paths in examples.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -269,7 +269,7 @@ jdeathe/centos-ssh-apache-php:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-apache-php" \
-	org.deathe.description="CentOS-6 6.10 x86_64 - Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1."
+	org.deathe.description="CentOS-6 6.10 x86_64 - Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP redis 2.2, PHP APC 3.1."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ centos-ssh-apache-php
 
 Docker Image including: 
 
-- CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
-- CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7.0.
-- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcache 7.2.
+- CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP redis 2.2, PHP APC 3.1.
+- CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, PHP redis 3.1, Zend Opcache 7.0.
+- CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, PHP redis 3.1, Zend Opcache 7.2.
 
 Apache PHP web server, loading only a minimal set of Apache modules by default. Supports custom configuration via environment variables.
 


### PR DESCRIPTION
CLOSES #673

- Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.