### PR TITLE
CLOSES #660: Updates wrapper to set httpd ErrorLog to /dev/stderr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.10 x86_64, Apache 2.4, PHP-FPM 5.6, PHP memcached 2.2, Zend Opcache 7
 
 - Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.
 - Updates description in centos-ssh-apache-php.register@.service.
+- Updates wrapper to set httpd ErrorLog to `/dev/stderr` instead of `/dev/stdout`.
 - Fixes README SSL/TLS data volume names/paths in examples.
 - Fixes bootstrap; ensure user creation occurs before setting ownership with user.
 - Removes unused `DOCKER_PORT_MAP_TCP_22` variable from environment includes.

--- a/src/usr/sbin/httpd-wrapper
+++ b/src/usr/sbin/httpd-wrapper
@@ -89,7 +89,7 @@ function main ()
 		__get_apache_operating_mode
 	)"
 
-	local options="-c \"ErrorLog /dev/stdout\" -D FOREGROUND -D ${mode}"
+	local options="-c \"ErrorLog /dev/stderr\" -D FOREGROUND -D ${mode}"
 
 	if [[ ${autostart_bootstrap} == false ]]
 	then


### PR DESCRIPTION
CLOSES #660

- Updates wrapper to set httpd ErrorLog to `/dev/stderr` instead of `/dev/stdout`.