### PR TITLE
CLOSES #661: Updates wrapper to set httpd ErrorLog to /dev/stderr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-6 6.10 x86_64, Apache 2.2, PHP 5.3, PHP memcached 1.0, PHP APC 3.1.
 
 - Updates Dockerfile `org.deathe.description` metadata LABEL to include PHP redis module.
 - Updates description in centos-ssh-apache-php.register@.service.
+- Updates wrapper to set httpd ErrorLog to `/dev/stderr` instead of `/dev/stdout`.
 - Fixes php_uname to gethostname replacment regex quoting.
 - Fixes README SSL/TLS data volume names/paths in examples.
 - Fixes bootstrap; ensure user creation occurs before setting ownership with user.

--- a/src/usr/sbin/httpd-wrapper
+++ b/src/usr/sbin/httpd-wrapper
@@ -89,7 +89,7 @@ function main ()
 		__get_apache_operating_mode
 	)"
 
-	local options="-c \"ErrorLog /dev/stdout\" -D FOREGROUND -D ${mode}"
+	local options="-c \"ErrorLog /dev/stderr\" -D FOREGROUND -D ${mode}"
 
 	if [[ ${autostart_bootstrap} == false ]]
 	then


### PR DESCRIPTION
CLOSES #661

- Updates wrapper to set httpd ErrorLog to `/dev/stderr` instead of `/dev/stdout`.