### PR TITLE
CLOSES #658: Adds PACKAGE_PATH placeholder/variable replacement in bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CentOS-7 7.5.1804 x86_64, Apache 2.4, PHP-FPM 7.2, PHP memcached 3.0, Zend Opcac
 - Updates description in centos-ssh-apache-php.register@.service.
 - Updates wrapper to set httpd ErrorLog to `/dev/stderr` instead of `/dev/stdout`.
 - Fixes bootstrap; ensure user creation occurs before setting ownership with user.
+- Adds `PACKAGE_PATH` placeholder/variable replacement in bootstrap of configuration files.
 - Removes unused `DOCKER_PORT_MAP_TCP_22` variable from environment includes.
 
 ### 3.2.0 - 2019-04-11

--- a/src/usr/sbin/httpd-bootstrap
+++ b/src/usr/sbin/httpd-bootstrap
@@ -1944,6 +1944,7 @@ function main ()
 		-e "s~(\\$\{|\{\{)APACHE_SSL_CIPHER_SUITE(\}\}|(:-.+)?\})~${apache_ssl_cipher_suite}~g" \
 		-e "s~(\\$\{|\{\{)APACHE_SSL_PROTOCOL(\}\}|(:-.+)?\})~${apache_ssl_protocol}~g" \
 		-e "s~(\\$\{|\{\{)APACHE_SYSTEM_USER(\}\}|(:-.+)?\})~${apache_system_user}~g" \
+		-e "s~(\\$\{|\{\{)PACKAGE_PATH(\}\}|(:-.+)?\})~${package_path}~g" \
 		-e "s~(\\$\{|\{\{)PHP_OPTIONS_DATE_TIMEZONE(\}\}|(:-.+)?\})~${php_options_date_timezone}~g" \
 		-e "s~(\\$\{|\{\{)PHP_OPTIONS_SESSION_NAME(\}\}|(:-.+)?\})~${php_options_session_name}~g" \
 		-e "s~(\\$\{|\{\{)PHP_OPTIONS_SESSION_SAVE_HANDLER(\}\}|(:-.+)?\})~${php_options_session_save_handler}~g" \


### PR DESCRIPTION
CLOSES #658

- Adds `PACKAGE_PATH` placeholder/variable replacement in bootstrap of configuration files.