### PR TITLE
CLOSES #734: Sets default PHP date.timezone to PHP_OPTIONS_DATE_TIMEZONE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Summary of release changes.
 ### 1.13.1 - Unreleased
 
 - Updates environment variable ordering for consistency.
+- Adds setting PHP `date.timezone` to `PHP_OPTIONS_DATE_TIMEZONE` into service configuration; removes dependency on app package configuration.
 - Removes PHP 5.6 image variant from listing in README; no longer maintained.
 
 ### 1.13.0 - 2019-07-15

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN useradd -r -M -d /var/www/app -s /sbin/nologin app \
 	&& sed -r \
 		-e 's~^;(user_ini.filename =)$~\1~g' \
 		-e 's~^;(cgi.fix_pathinfo=1)$~\1~g' \
-		-e 's~^;(date.timezone =)$~\1 UTC~g' \
+		-e 's~^;(date.timezone =)$~\1 "${PHP_OPTIONS_DATE_TIMEZONE:-UTC}"~g' \
 		-e 's~^(expose_php = )On$~\1Off~g' \
 		-e 's~^;(realpath_cache_size = ).*$~\14096k~' \
 		-e 's~^;(realpath_cache_ttl = ).*$~\1600~' \


### PR DESCRIPTION
CLOSES #734 